### PR TITLE
feat: Dashboard stabilization - multi-tenancy, chain ownership, locked status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Acknowledgements
 
 This project is based on the ideas and original implementation of
-[original-project-name](https://github.com/xxx/yyy),
+[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote),
 licensed under the MIT License.
 
-This is a full rewrite in <New Language> with additional features.
+This project is going to fully rewrite in <New Language> with additional features.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -80,6 +80,11 @@
      - **자동 모드:** 에이전트가 백그라운드에서 `tmux` 세션을 직접 생성하고 `claude` 명령어를 실행한다. 사용자는 `tmux attach` 명령어로 세션에 접속할 수 있다.
      - **수동 모드:** 사용자가 직접 `tmux` 세션을 시작하고, 해당 세션 정보를 에이전트에게 입력하여 연결한다.
   4. 세션이 성공적으로 설정되면 에이전트는 일반 작업 모드로 전환되고, `request_claude_session` 태스크는 자동으로 완료 처리된다.
+  5. `request_claude_session` 완료 처리는 일반 `task.completed` 이벤트와 분리된 전용 이벤트(`agent.automation.session_request.completed`)로 수행한다.
+     - Coordinator는 세션 요청 태스크 생성 시 `agent_session_request_token`을 함께 발급한다.
+     - Agent는 세션 할당/자동 실행이 완료되면 전용 이벤트 payload에 canonical 키 `agent_session_request_token`만 포함해 전송한다.
+     - Coordinator는 `agent_session_request_token`(및 선택적으로 `task_id`)으로 대상 세션 요청 태스크를 식별하여 `done`으로 전이한다.
+     - 전용 완료 이벤트 처리 시 task 상태 전이가 실패하면 성공으로 무시하지 않고 명시적으로 에러를 반환한다.
 
 ### 4.9 에이전트 인터랙티브 CLI 플로우
 - `login` 완료 후 자동으로 work 설정 진입 여부를 프롬프트로 물어봄

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -77,6 +77,10 @@
   - Locked Task는 In Progress 컬럼에 시각적으로 구분되어 표시 (dashed border, amber 색상)
   - Locked Task에 "→ Queued" / "→ Done" 버튼으로 상태 전환
   - Agent 미할당 또는 locked 상태의 Chain에 Agent 할당 드롭다운 제공
+- **체인 수동 할당 구독 검증**:
+  - `POST /v1/chains/{id}/assign-agent` 호출 시 대상 Agent가 해당 Chain의 채널을 `subscriptions`에 포함하고 있는지 서버에서 검증해야 한다.
+  - 미구독 상태면 서버는 명시적 오류 코드를 반환해야 한다(프론트 분기 가능).
+  - 대시보드는 이 오류를 받으면 사용자에게 채널 구독 추가 여부를 확인하고, 승인 시 `PATCH /v1/agents/{id}/channels`로 채널을 추가한 뒤 할당을 재시도해야 한다.
 - **API 엔드포인트**:
   - `POST /v1/chains/{id}/detach` — Agent를 Chain에서 분리
   - `POST /v1/tasks/{id}/status` — Locked Task 상태 전환 (locked→queued 또는 locked→done만 허용)

--- a/coordinator/internal/httpapi/bus.go
+++ b/coordinator/internal/httpapi/bus.go
@@ -6,18 +6,20 @@ import (
 )
 
 const (
-	EventAgents   = "agents"
-	EventTasks    = "tasks"
-	EventChannels = "channels"
-	EventChains   = "chains"
-	EventInputs   = "inputs"
-	EventEvents   = "events"
-	EventUpdate   = "update"
+	EventAgents       = "agents"
+	EventTasks        = "tasks"
+	EventChannels     = "channels"
+	EventChains       = "chains"
+	EventInputs       = "inputs"
+	EventEvents       = "events"
+	EventUpdate       = "update"
+	EventNotification = "notification"
 )
 
 type busEvent struct {
-	Type string    `json:"type"`
-	Time time.Time `json:"time"`
+	Type    string         `json:"type"`
+	Time    time.Time      `json:"time"`
+	Payload map[string]any `json:"payload,omitempty"`
 }
 
 type subscriber struct {
@@ -53,10 +55,14 @@ func (b *eventBus) Unsubscribe(ch chan busEvent) {
 }
 
 func (b *eventBus) Publish(typ string, userID string) {
+	b.PublishWithPayload(typ, userID, nil)
+}
+
+func (b *eventBus) PublishWithPayload(typ string, userID string, payload map[string]any) {
 	if typ == "" {
 		typ = EventUpdate
 	}
-	ev := busEvent{Type: typ, Time: time.Now().UTC()}
+	ev := busEvent{Type: typ, Time: time.Now().UTC(), Payload: payload}
 
 	b.mu.Lock()
 	for _, sub := range b.subs {

--- a/coordinator/internal/httpapi/handlers.go
+++ b/coordinator/internal/httpapi/handlers.go
@@ -184,15 +184,31 @@ func (s *Server) handleAgentsRequestSession(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// This creates a special task that signals headless agents to prompt for setup.
-	task, err := s.store.CreateTask(r.Context(), model.Task{
+	// Auto-create a chain for this session request task
+	newChain, err := s.store.CreateChain(r.Context(), model.Chain{
 		UserID:      userID,
 		ChannelID:   channelID,
-		Title:       "Agent Session Request",
-		Description: "Automatic request for an agent on this channel to start a new Claude session.",
-		Type:        "request_claude_session",
-		Status:      model.TaskStatusQueued,
-		Priority:    100, // High priority
+		Name:        "Session Request",
+		Description: "Auto-created chain for agent session request",
+		Status:      model.ChainStatusQueued,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", fmt.Sprintf("failed to create chain for session request: %v", err))
+		return
+	}
+
+	// This creates a special task that signals headless agents to prompt for setup.
+	task, err := s.store.CreateTask(r.Context(), model.Task{
+		UserID:                   userID,
+		ChannelID:                channelID,
+		ChainID:                  newChain.ID,
+		Sequence:                 1,
+		Title:                    "Agent Session Request",
+		Description:              "Automatic request for an agent on this channel to start a new Claude session.",
+		Type:                     "request_claude_session",
+		AgentSessionRequestToken: newAgentSessionRequestToken(),
+		Status:                   model.TaskStatusQueued,
+		Priority:                 100, // High priority
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal", fmt.Sprintf("failed to create session request task: %v", err))
@@ -949,6 +965,98 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "bad_json", "invalid json")
 			return
+		}
+
+		eventTaskID := strings.TrimSpace(req.TaskID)
+
+		if strings.EqualFold(strings.TrimSpace(req.Type), "agent.automation.session_request.completed") {
+			token := extractSessionRequestToken(req.Payload)
+			if token == "" {
+				writeError(w, http.StatusBadRequest, "invalid_request", "agent_session_request_token is required for session request completion event")
+				return
+			}
+
+			// Find session request task by token (+optional task_id), then complete deterministically.
+			candidateTaskID := strings.TrimSpace(req.TaskID)
+			if candidateTaskID == "" {
+				candidateTaskID = extractSessionRequestTaskID(req.Payload)
+			}
+			if eventTaskID == "" {
+				eventTaskID = candidateTaskID
+			}
+
+			allTasks, err := s.store.ListTasks(r.Context(), store.TaskFilter{
+				UserID: userID,
+			})
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "internal", "failed to list tasks")
+				return
+			}
+
+			var selected *model.Task
+			var selectedByID *model.Task
+			var selectedInProgress *model.Task
+			var selectedDone *model.Task
+			for i := range allTasks {
+				t := &allTasks[i]
+				if t.Type != "request_claude_session" {
+					continue
+				}
+				if strings.TrimSpace(t.AgentSessionRequestToken) != token {
+					continue
+				}
+				if candidateTaskID != "" && t.ID == candidateTaskID {
+					selectedByID = t
+				}
+				if t.Status == model.TaskStatusInProgress && selectedInProgress == nil {
+					selectedInProgress = t
+				}
+				if t.Status == model.TaskStatusDone && selectedDone == nil {
+					selectedDone = t
+				}
+				if selected == nil {
+					selected = t
+				}
+			}
+
+			if selected == nil {
+				writeError(w, http.StatusNotFound, "not_found", "session request task not found for token")
+				return
+			}
+
+			target := selected
+			if candidateTaskID != "" {
+				if selectedByID == nil {
+					writeError(w, http.StatusConflict, "conflict", "task_id does not match token owner task")
+					return
+				}
+				target = selectedByID
+			} else if selectedInProgress != nil {
+				target = selectedInProgress
+			} else if selectedDone != nil {
+				target = selectedDone
+			}
+			eventTaskID = target.ID
+
+			switch target.Status {
+			case model.TaskStatusDone:
+				// already completed; idempotent no-op
+			case model.TaskStatusInProgress:
+				// For token-gated session request completion, bypass current_task_id coupling.
+				_, err = s.store.CompleteTask(r.Context(), store.CompleteTaskRequest{
+					TaskID:  target.ID,
+					AgentID: "",
+				})
+				if err != nil {
+					writeError(w, http.StatusConflict, "conflict", fmt.Sprintf("failed to complete session request task: %v", err))
+					return
+				}
+				s.bus.Publish(EventTasks, userID)
+				s.bus.Publish(EventChains, userID)
+			default:
+				writeError(w, http.StatusConflict, "conflict", "session request task is not in progress")
+				return
+			}
 		}
 
 		e, err := s.store.CreateEvent(r.Context(), model.Event{

--- a/coordinator/internal/httpapi/middleware.go
+++ b/coordinator/internal/httpapi/middleware.go
@@ -101,12 +101,6 @@ func authMiddleware(cfg config.Config, next http.Handler) http.Handler {
 			}
 		}
 
-		// If no API token configured, auth requires JWT only (checked above).
-		if apiToken == "" {
-			writeError(w, http.StatusUnauthorized, "unauthorized", "missing or invalid credentials")
-			return
-		}
-
 		// --- Query param tokens (for SSE/EventSource which can't set headers) ---
 		if r.Method == http.MethodGet {
 			// Try JWT via query param

--- a/coordinator/internal/httpapi/notifications.go
+++ b/coordinator/internal/httpapi/notifications.go
@@ -1,0 +1,120 @@
+package httpapi
+
+import (
+	"sync"
+	"time"
+)
+
+const notificationCooldown = 5 * time.Minute
+
+// Notification represents a stored notification visible to a user.
+type Notification struct {
+	Key       string         `json:"key"` // unique: "agentID:type"
+	UserID    string         `json:"user_id"`
+	AgentID   string         `json:"agent_id"`
+	AgentName string         `json:"agent_name"`
+	Type      string         `json:"type"`    // e.g. "setup_waiting"
+	Channel   string         `json:"channel"` // first subscribed channel (may be empty)
+	Message   string         `json:"message"`
+	CreatedAt time.Time      `json:"created_at"`
+	Extra     map[string]any `json:"extra,omitempty"`
+}
+
+// notificationTracker stores active notifications per user and prevents duplicate sends.
+type notificationTracker struct {
+	mu    sync.Mutex
+	sent  map[string]time.Time      // cooldown tracker, key: "agentID:type"
+	items map[string][]Notification // stored notifications, key: userID
+}
+
+func newNotificationTracker() *notificationTracker {
+	return &notificationTracker{
+		sent:  make(map[string]time.Time),
+		items: make(map[string][]Notification),
+	}
+}
+
+func (n *notificationTracker) cooldownKey(agentID, typ string) string {
+	return agentID + ":" + typ
+}
+
+// ShouldNotify returns true if this agent+type hasn't been notified within the cooldown.
+func (n *notificationTracker) ShouldNotify(agentID, typ string) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	k := n.cooldownKey(agentID, typ)
+	last, ok := n.sent[k]
+	if ok && time.Since(last) < notificationCooldown {
+		return false
+	}
+	n.sent[k] = time.Now()
+	return true
+}
+
+// Add stores a notification. Replaces any existing notification with the same key for this user.
+func (n *notificationTracker) Add(notif Notification) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	list := n.items[notif.UserID]
+	// Replace if exists
+	for i, existing := range list {
+		if existing.Key == notif.Key {
+			list[i] = notif
+			return
+		}
+	}
+	n.items[notif.UserID] = append(list, notif)
+}
+
+// List returns all stored notifications for a user.
+func (n *notificationTracker) List(userID string) []Notification {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	list := n.items[userID]
+	if list == nil {
+		return []Notification{}
+	}
+	// Return a copy
+	out := make([]Notification, len(list))
+	copy(out, list)
+	return out
+}
+
+// Dismiss removes a notification by agentID+type for a user and clears the cooldown.
+func (n *notificationTracker) Dismiss(userID, agentID, typ string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	key := n.cooldownKey(agentID, typ)
+	delete(n.sent, key)
+
+	list := n.items[userID]
+	for i, item := range list {
+		if item.Key == key {
+			n.items[userID] = append(list[:i], list[i+1:]...)
+			return
+		}
+	}
+}
+
+// ClearByAgent removes all notifications for a specific agent+type across all users,
+// and clears the cooldown. Used when agent exits setup_waiting.
+func (n *notificationTracker) ClearByAgent(agentID, typ string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	key := n.cooldownKey(agentID, typ)
+	delete(n.sent, key)
+
+	for userID, list := range n.items {
+		for i, item := range list {
+			if item.Key == key {
+				n.items[userID] = append(list[:i], list[i+1:]...)
+				break
+			}
+		}
+	}
+}

--- a/coordinator/internal/httpapi/server.go
+++ b/coordinator/internal/httpapi/server.go
@@ -8,19 +8,21 @@ import (
 )
 
 type Server struct {
-	cfg   config.Config
-	store store.Store
-	mux   *http.ServeMux
-	bus   *eventBus
+	cfg     config.Config
+	store   store.Store
+	mux     *http.ServeMux
+	bus     *eventBus
+	notifTk *notificationTracker
 }
 
 func NewServer(cfg config.Config, st store.Store) *Server {
 	initJWTKey(cfg.JWTSecret)
 	s := &Server{
-		cfg:   cfg,
-		store: st,
-		mux:   http.NewServeMux(),
-		bus:   newEventBus(),
+		cfg:     cfg,
+		store:   st,
+		mux:     http.NewServeMux(),
+		bus:     newEventBus(),
+		notifTk: newNotificationTracker(),
 	}
 	s.registerRoutes()
 	return s
@@ -55,7 +57,10 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/v1/channels", s.handleChannels)
 	s.mux.HandleFunc("GET /v1/channels/by-name/{name}", s.handleGetChannelByName)
 	s.mux.HandleFunc("/v1/chains", s.handleChains)
+	s.mux.HandleFunc("POST /v1/chains/{id}/detach", s.handleChainDetach)
+	s.mux.HandleFunc("POST /v1/chains/{id}/assign-agent", s.handleChainAssignAgent)
 	s.mux.HandleFunc("/v1/chains/{id}", s.handleChain)
+	s.mux.HandleFunc("POST /v1/tasks/{id}/status", s.handleTaskUpdateStatus)
 	s.mux.HandleFunc("/v1/tasks", s.handleTasks)
 	s.mux.HandleFunc("/v1/tasks/claim", s.handleTasksClaim)
 	s.mux.HandleFunc("/v1/tasks/assign", s.handleTasksAssign)

--- a/coordinator/internal/httpapi/server.go
+++ b/coordinator/internal/httpapi/server.go
@@ -64,6 +64,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/v1/tasks/inputs", s.handleTaskInputs)
 	s.mux.HandleFunc("/v1/tasks/inputs/claim", s.handleTaskInputsClaim)
 
+	s.mux.HandleFunc("GET /v1/notifications", s.handleNotificationsList)
+	s.mux.HandleFunc("POST /v1/notifications/dismiss", s.handleNotificationDismiss)
+
 	s.mux.HandleFunc("/v1/events", s.handleEvents)
 	s.mux.HandleFunc("/v1/stream", s.handleStream)
 	s.mux.HandleFunc("/v1/dashboard", s.handleDashboard)

--- a/coordinator/internal/httpapi/ui/app.js
+++ b/coordinator/internal/httpapi/ui/app.js
@@ -930,11 +930,32 @@ async function main() {
       await refresh().catch(() => {});
     };
 
-    input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
-      if (e.key === 'Escape') { e.preventDefault(); refresh().catch(() => {}); }
-    });
-    input.addEventListener('blur', save, { once: true });
+    const cancel = () => {
+      if (finished) return;
+      finished = true;
+      input.removeEventListener('keydown', onKeyDown);
+      input.removeEventListener('blur', onBlur);
+      if (document.activeElement === input) input.blur();
+      renderCellValue(currentSubs, 'cancelled');
+      refresh().catch(() => {});
+    };
+
+    const onKeyDown = (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        save().catch(() => {});
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        cancel();
+      }
+    };
+    const onBlur = () => {
+      save().catch(() => {});
+    };
+
+    input.addEventListener('keydown', onKeyDown);
+    input.addEventListener('blur', onBlur);
   });
 
   els.taskChannel.addEventListener('change', () => {

--- a/coordinator/internal/httpapi/ui/app.js
+++ b/coordinator/internal/httpapi/ui/app.js
@@ -768,7 +768,22 @@ async function main() {
         openPromptModal(task_id);
         return;
       }
-      if (action === 'complete') {
+      if (action === 'detach') {
+        const chainId = btn.getAttribute('data-chain-id');
+        const agentId = btn.getAttribute('data-agent-id');
+        if (!chainId || !agentId) return;
+        await api(`/v1/chains/${encodeURIComponent(chainId)}/detach`, {
+          method: 'POST',
+          body: JSON.stringify({ agent_id: agentId }),
+        });
+      } else if (action === 'task-status') {
+        const status = btn.getAttribute('data-status');
+        if (!task_id || !status) return;
+        await api(`/v1/tasks/${encodeURIComponent(task_id)}/status`, {
+          method: 'POST',
+          body: JSON.stringify({ status }),
+        });
+      } else if (action === 'complete') {
         await api('/v1/tasks/complete', {
           method: 'POST',
           body: JSON.stringify({ task_id }),
@@ -786,6 +801,24 @@ async function main() {
           body: JSON.stringify({ task_id, agent_id }),
         });
       }
+      await refresh();
+    } catch (err) {
+      showError(err);
+    }
+  });
+
+  // Agent assignment dropdown on chain cards
+  els.taskBoard.addEventListener('change', async (ev) => {
+    const dropdown = ev.target?.closest?.('.agent-assign-dropdown');
+    if (!dropdown) return;
+    const chainId = dropdown.getAttribute('data-chain-id');
+    const agentId = dropdown.value;
+    if (!chainId || !agentId) return;
+    try {
+      await api(`/v1/chains/${encodeURIComponent(chainId)}/assign-agent`, {
+        method: 'POST',
+        body: JSON.stringify({ agent_id: agentId }),
+      });
       await refresh();
     } catch (err) {
       showError(err);

--- a/coordinator/internal/httpapi/ui/dashboard.html
+++ b/coordinator/internal/httpapi/ui/dashboard.html
@@ -146,6 +146,29 @@
       </div>
     </div>
 
+    <!-- Toast Container (top-right floating popups) -->
+    <div id="toastContainer" class="toast-container"></div>
+
+    <!-- Notification Bell (always visible) -->
+    <button id="notifBell" class="notification-bell">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+        <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+      </svg>
+      <span id="notifBadge" class="notification-badge" style="display:none;">0</span>
+    </button>
+
+    <!-- Notification Panel (history list, opens on bell click) -->
+    <div id="notifPanel" class="notification-panel hidden">
+      <div class="notification-panel-header">
+        <span class="notification-panel-title">Notifications</span>
+        <button id="notifPanelClose" class="btn" style="padding:4px 8px;font-size:11px;">Close</button>
+      </div>
+      <div id="notifList" class="notification-list">
+        <div class="muted" style="padding:12px;text-align:center;">No notifications</div>
+      </div>
+    </div>
+
     <footer class="footer">
       <div>Polling-based MVP. Real-time (SSE/WS/Supabase Realtime) will come later.</div>
     </footer>

--- a/coordinator/internal/httpapi/ui/styles.css
+++ b/coordinator/internal/httpapi/ui/styles.css
@@ -241,6 +241,12 @@ input::placeholder { color: rgba(169,175,191,0.65); }
 .task-in_progress { border-left: 3px solid rgba(255,204,102,0.7); }
 .task-done { border-left: 3px solid rgba(61,220,151,0.7); }
 .task-failed { border-left: 3px solid rgba(255,92,122,0.7); }
+.task-locked {
+  border-left: 3px dashed rgba(255,170,60,0.8);
+  background: rgba(255,170,60,0.06);
+  border-style: dashed;
+  border-color: rgba(255,170,60,0.35);
+}
 .task-title { font-weight: 650; font-size: 13px; margin-bottom: 4px; }
 .task-desc { font-size: 12px; color: var(--muted); white-space: pre-wrap; }
 
@@ -273,6 +279,53 @@ input::placeholder { color: rgba(169,175,191,0.65); }
 .badge.success { color: var(--ok); }
 .badge.not-running { color: var(--danger); }
 .badge.muted-badge { color: var(--muted); opacity: 0.7; }
+.badge.locked { color: rgba(255,170,60,0.9); }
+
+.chain-locked {
+  border-color: rgba(255,170,60,0.35);
+  background: rgba(255,170,60,0.04);
+}
+
+.chain-owner {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--primary);
+  margin-left: 8px;
+}
+
+.detach-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  margin-left: 4px;
+  border: 1px solid rgba(255,92,122,0.4);
+  border-radius: 50%;
+  background: rgba(255,92,122,0.1);
+  color: var(--danger);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  line-height: 1;
+}
+.detach-btn:hover {
+  background: rgba(255,92,122,0.25);
+  border-color: rgba(255,92,122,0.6);
+}
+
+.agent-assign-dropdown {
+  width: auto;
+  min-width: 140px;
+  height: 28px;
+  padding: 2px 8px;
+  font-size: 11px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: rgba(0,0,0,0.22);
+  color: var(--text);
+}
 
 .footer {
   padding: 18px 22px;

--- a/coordinator/internal/httpapi/ui/styles.css
+++ b/coordinator/internal/httpapi/ui/styles.css
@@ -345,3 +345,191 @@ input::placeholder { color: rgba(169,175,191,0.65); }
 .modal-controls { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 10px; }
 .modal-footer { display: grid; grid-template-columns: 1fr auto; gap: 10px; }
 .modal-status { margin-top: 8px; }
+
+/* --- Notification Bell --- */
+.notification-bell {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 100;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: 1px solid rgba(110,168,254,0.45);
+  background: linear-gradient(135deg, var(--primary), var(--primary2));
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 8px 32px rgba(76,125,255,0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.notification-bell:hover {
+  transform: scale(1.08);
+  box-shadow: 0 10px 40px rgba(76,125,255,0.5);
+}
+.notification-bell.has-notif {
+  animation: bellPulse 2s ease-in-out infinite;
+}
+@keyframes bellPulse {
+  0%, 100% { box-shadow: 0 8px 32px rgba(76,125,255,0.35); }
+  50% { box-shadow: 0 8px 32px rgba(255,92,122,0.5); }
+}
+
+.notification-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--danger);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+  border: 2px solid var(--bg);
+}
+
+/* --- Notification Panel --- */
+.notification-panel {
+  position: fixed;
+  bottom: 90px;
+  right: 24px;
+  z-index: 99;
+  width: 380px;
+  max-height: 420px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: rgba(17,21,34,0.96);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 16px 48px rgba(0,0,0,0.45);
+  overflow: hidden;
+  animation: panelSlideUp 0.2s ease-out;
+}
+.notification-panel.hidden {
+  display: none;
+}
+@keyframes panelSlideUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.notification-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.notification-panel-title {
+  font-weight: 700;
+  font-size: 14px;
+}
+
+.notification-list {
+  overflow-y: auto;
+  max-height: 360px;
+  padding: 8px;
+}
+
+.notification-item {
+  border: 1px solid var(--border);
+  background: rgba(255,255,255,0.03);
+  border-radius: 10px;
+  padding: 12px;
+  margin-bottom: 8px;
+}
+.notification-item:last-child { margin-bottom: 0; }
+.notification-item-title {
+  font-weight: 650;
+  font-size: 13px;
+  margin-bottom: 4px;
+  color: var(--warn);
+}
+.notification-item-msg {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+.notification-item-actions {
+  display: flex;
+  gap: 8px;
+}
+.notification-item-actions .btn {
+  padding: 6px 12px;
+  font-size: 12px;
+}
+
+/* --- Toast Container (top-right floating popups) --- */
+.toast-container {
+  position: fixed;
+  top: 80px;
+  right: 24px;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 400px;
+  pointer-events: none;
+}
+.toast-item {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 14px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(255,204,102,0.35);
+  background: rgba(17,21,34,0.96);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 12px 40px rgba(0,0,0,0.45);
+  animation: toastSlideIn 0.25s ease-out;
+}
+@keyframes toastSlideIn {
+  from { opacity: 0; transform: translateX(40px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+.toast-content { flex: 1; min-width: 0; }
+.toast-title { font-weight: 650; font-size: 13px; color: var(--warn); margin-bottom: 4px; }
+.toast-msg { font-size: 12px; color: var(--muted); margin-bottom: 8px; }
+.toast-actions { display: flex; gap: 8px; align-items: center; }
+.toast-actions .btn { padding: 5px 10px; font-size: 11px; }
+.toast-close {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: rgba(255,255,255,0.05);
+  color: var(--muted);
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+.toast-close:hover { background: rgba(255,255,255,0.1); color: var(--text); }
+
+.notification-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+.notification-item-time {
+  font-size: 11px;
+  color: var(--muted);
+  opacity: 0.7;
+}
+
+@media (max-width: 480px) {
+  .notification-panel { width: calc(100vw - 32px); right: 16px; }
+  .notification-bell { bottom: 16px; right: 16px; }
+  .toast-container { right: 16px; left: 16px; max-width: none; }
+}

--- a/coordinator/internal/model/model.go
+++ b/coordinator/internal/model/model.go
@@ -34,6 +34,7 @@ const (
 	TaskStatusInProgress TaskStatus = "in_progress"
 	TaskStatusDone       TaskStatus = "done"
 	TaskStatusFailed     TaskStatus = "failed"
+	TaskStatusLocked     TaskStatus = "locked"
 )
 
 type ExecutionMode string
@@ -51,6 +52,7 @@ const (
 	ChainStatusInProgress ChainStatus = "in_progress"
 	ChainStatusDone       ChainStatus = "done"
 	ChainStatusFailed     ChainStatus = "failed"
+	ChainStatusLocked     ChainStatus = "locked"
 )
 
 type Agent struct {

--- a/coordinator/internal/model/model.go
+++ b/coordinator/internal/model/model.go
@@ -83,33 +83,35 @@ type Channel struct {
 }
 
 type Chain struct {
-	ID          string      `json:"id"`
-	UserID      string      `json:"user_id,omitempty"`
-	ChannelID   string      `json:"channel_id"`
-	Name        string      `json:"name"`
-	Description string      `json:"description,omitempty"`
-	Status      ChainStatus `json:"status"`
-	CreatedAt   time.Time   `json:"created_at"`
-	UpdatedAt   time.Time   `json:"updated_at"`
+	ID           string      `json:"id"`
+	UserID       string      `json:"user_id,omitempty"`
+	ChannelID    string      `json:"channel_id"`
+	Name         string      `json:"name"`
+	Description  string      `json:"description,omitempty"`
+	Status       ChainStatus `json:"status"`
+	OwnerAgentID string      `json:"owner_agent_id,omitempty"` // Agent that owns this chain
+	CreatedAt    time.Time   `json:"created_at"`
+	UpdatedAt    time.Time   `json:"updated_at"`
 }
 
 type Task struct {
-	ID              string        `json:"id"`
-	UserID          string        `json:"user_id,omitempty"`
-	ChainID         string        `json:"chain_id,omitempty"` // New field to link to a chain
-	Sequence        int           `json:"sequence,omitempty"` // New field for order within a chain
-	ChannelID       string        `json:"channel_id"`
-	Title           string        `json:"title"`
-	Description     string        `json:"description,omitempty"`
-	Type            string        `json:"type,omitempty"`
-	Status          TaskStatus    `json:"status"`
-	Priority        int           `json:"priority"`
-	AssignedAgentID string        `json:"assigned_agent_id,omitempty"`
-	ExecutionMode   ExecutionMode `json:"execution_mode,omitempty"` // Claude Code execution mode
-	CreatedAt       time.Time     `json:"created_at"`
-	ClaimedAt       *time.Time    `json:"claimed_at,omitempty"`
-	DoneAt          *time.Time    `json:"done_at,omitempty"`
-	UpdatedAt       time.Time     `json:"updated_at"`
+	ID                       string        `json:"id"`
+	UserID                   string        `json:"user_id,omitempty"`
+	ChainID                  string        `json:"chain_id,omitempty"` // New field to link to a chain
+	Sequence                 int           `json:"sequence,omitempty"` // New field for order within a chain
+	ChannelID                string        `json:"channel_id"`
+	Title                    string        `json:"title"`
+	Description              string        `json:"description,omitempty"`
+	Type                     string        `json:"type,omitempty"`
+	AgentSessionRequestToken string        `json:"agent_session_request_token,omitempty"`
+	Status                   TaskStatus    `json:"status"`
+	Priority                 int           `json:"priority"`
+	AssignedAgentID          string        `json:"assigned_agent_id,omitempty"`
+	ExecutionMode            ExecutionMode `json:"execution_mode,omitempty"` // Claude Code execution mode
+	CreatedAt                time.Time     `json:"created_at"`
+	ClaimedAt                *time.Time    `json:"claimed_at,omitempty"`
+	DoneAt                   *time.Time    `json:"done_at,omitempty"`
+	UpdatedAt                time.Time     `json:"updated_at"`
 }
 
 type Event struct {

--- a/coordinator/internal/store/store.go
+++ b/coordinator/internal/store/store.go
@@ -69,6 +69,11 @@ type ClaimTaskInputRequest struct {
 	AgentID string `json:"agent_id"`
 }
 
+type DetachAgentFromChainRequest struct {
+	ChainID string `json:"chain_id"`
+	AgentID string `json:"agent_id"`
+}
+
 type Store interface {
 	UpsertAgent(ctx context.Context, a model.Agent) (model.Agent, error)
 	GetAgent(ctx context.Context, id string) (*model.Agent, error)
@@ -83,6 +88,7 @@ type Store interface {
 	ListChains(ctx context.Context, userID string, channelID string) ([]model.Chain, error)
 	UpdateChain(ctx context.Context, c model.Chain) (model.Chain, error)
 	DeleteChain(ctx context.Context, id string) error
+	DetachAgentFromChain(ctx context.Context, req DetachAgentFromChainRequest) error
 
 	CreateTask(ctx context.Context, t model.Task) (model.Task, error)
 	ListTasks(ctx context.Context, f TaskFilter) ([]model.Task, error)
@@ -90,6 +96,7 @@ type Store interface {
 	AssignTask(ctx context.Context, req AssignTaskRequest) (*model.Task, error)
 	CompleteTask(ctx context.Context, req CompleteTaskRequest) (*model.Task, error)
 	FailTask(ctx context.Context, req FailTaskRequest) (*model.Task, error)
+	UpdateTaskStatus(ctx context.Context, taskID string, newStatus model.TaskStatus) (*model.Task, error)
 
 	CreateEvent(ctx context.Context, e model.Event) (model.Event, error)
 	ListEvents(ctx context.Context, f EventFilter) ([]model.Event, error)

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -9,7 +9,7 @@ IMAGE_TAG="${IMAGE_TAG:-latest}"
 PLATFORMS="linux/amd64,linux/arm64"
 DOCKERFILE="../coordinator/Dockerfile"
 BUILD_CONTEXT=".."
-ENV_FILE="../.env"
+ENV_FILE="../.env.prod"
 
 ############################################
 # 1. Load .env and export variables
@@ -31,7 +31,7 @@ if ! docker info 2>/dev/null | grep -q "Username"; then
   echo "🔑 Docker login required"
 
   : "${DOCKER_USERNAME:?DOCKER_USERNAME not set}"
-  : "${DOCKER_PASSWORD:?DOCKER_PASSWORD not set}"
+  : "${DOCKER_PAT:?DOCKER_PAT not set}"
 
   echo "$DOCKER_PAT" | docker login \
     -u "$DOCKER_USERNAME" \

--- a/tasks/0044-enforce-chain-id-required.md
+++ b/tasks/0044-enforce-chain-id-required.md
@@ -1,0 +1,22 @@
+# Enforce chain_id Required for All Tasks
+
+## 요구사항
+- REQUIREMENTS.md 참조: 모든 태스크는 반드시 체인에 속해야 함
+
+## 작업 목록
+- [x] Store 레벨: CreateTask에 chain_id 필수 검증 추가 (memory + postgres)
+- [x] ClaimTask: standalone 태스크 fallback 제거 (memory)
+- [x] SQL claim_task 함수: 3번째 fallback 제거 (새 마이그레이션)
+- [x] handleAgentsRequestSession: 자동 체인 생성 적용
+- [x] DB 스키마: chain_id NOT NULL + ON DELETE CASCADE 마이그레이션
+- [x] UI: Standalone Tasks 섹션 제거
+- [x] 테스트 수정 (memory + postgres)
+
+## 변경 파일
+- `coordinator/internal/store/memory/memory.go`
+- `coordinator/internal/store/postgres/postgres.go`
+- `coordinator/internal/httpapi/handlers.go`
+- `coordinator/internal/httpapi/ui/app.js`
+- `coordinator/internal/store/memory/memory_test.go`
+- `coordinator/internal/store/postgres/postgres_test.go`
+- `supabase/migrations/0011_enforce_chain_id.sql`

--- a/tasks/0045-fix-agent-endpoints-multi-tenancy.md
+++ b/tasks/0045-fix-agent-endpoints-multi-tenancy.md
@@ -1,0 +1,18 @@
+# Fix Agent Endpoints Multi-Tenancy
+
+## 요구사항
+- Multi-tenancy 도입으로 모든 API 엔드포인트는 user_id 기반 접근 제어 필요
+- Agent 조회 시 요청자의 user_id와 agent의 user_id 일치 여부 검증 필요
+
+## 문제점
+- `GET /v1/agents/{id}/current-task`: user_id 검증 없음
+- `GET /v1/agents/{id}`: user_id 검증 없음
+- 다른 유저의 agent 정보에 무단 접근 가능
+
+## 작업 목록
+- [x] `handleAgentCurrentTask`: user_id 검증 추가
+- [x] `handleGetAgent`: user_id 검증 추가
+- [ ] 에러 케이스 테스트
+
+## 변경 파일
+- `coordinator/internal/httpapi/handlers.go`

--- a/tasks/0046-chain-ownership-exclusivity.md
+++ b/tasks/0046-chain-ownership-exclusivity.md
@@ -1,0 +1,141 @@
+# Chain Ownership 및 독점성 구현
+
+## 요구사항
+- REQUIREMENTS.md 참조: 4.4.1 Chain Ownership 및 독점성 (Exclusivity)
+
+## 목표
+Agent가 동시에 하나의 Chain만 소유하고, Chain을 소유한 Agent만 해당 Chain의 Task를 claim할 수 있도록 chain-level ownership과 exclusivity를 구현한다.
+
+## 핵심 규칙
+1. **Single chain ownership**: Agent는 동시에 하나의 Chain에 대해서만 소유권을 가질 수 있다
+2. **Ownership 획득**: Agent가 Chain의 첫 번째 Task를 claim하면 해당 Chain의 소유권을 자동으로 획득한다
+3. **Ownership 유지**: Agent가 Chain을 소유하는 동안 다른 Chain의 Task를 claim할 수 없다
+4. **독점적 접근**: Chain을 소유한 Agent만 해당 Chain의 Task를 claim할 수 있다
+5. **Ownership 해제**: Chain의 모든 Task가 완료/실패하면 소유권이 자동으로 해제된다
+
+## 작업 목록
+
+### 1. 데이터 모델 변경
+- [x] chains 테이블에 `owner_agent_id` 컬럼 추가 (migration)
+- [x] model.Chain에 `OwnerAgentID` 필드 추가
+- [x] Agent에서 현재 소유한 chain 조회 로직 추가
+
+### 2. claim_task 함수 수정 (Postgres)
+- [x] Agent의 현재 chain ownership 체크 로직 추가 (migration에 구현)
+- [x] Agent가 chain을 소유하면 그 chain의 task만 claim 가능하도록 제약
+- [x] Chain의 첫 task를 claim할 때 chain.owner_agent_id 설정
+- [x] 다른 agent가 소유한 chain의 task는 claim 불가
+
+### 3. 메모리 스토어 구현
+- [x] memory.go의 ClaimTask에 chain ownership 로직 추가
+- [x] chain ownership 상태를 메모리에서 추적
+
+### 4. Chain ownership 해제 로직
+- [x] CompleteTask 시 chain의 모든 task 완료 여부 체크
+- [x] FailTask 시 chain의 owner_agent_id 해제 여부 결정
+- [x] chain 완료/실패 시 owner_agent_id를 NULL로 설정
+- [x] Postgres: trigger를 통한 자동 해제
+- [x] Memory: checkAndReleaseChainOwnership helper 함수
+
+### 5. API 엔드포인트 추가 (선택사항)
+- [ ] POST /v1/chains/detach - 수동 chain ownership 해제
+- [ ] GET /v1/agents/:id/chain - Agent의 현재 소유 chain 조회
+
+### 6. 테스트
+- [ ] Postgres store chain ownership 테스트 추가 (TODO: postgres_test.go)
+- [x] Memory store chain ownership 테스트 추가 (TestChainOwnership)
+- [x] 여러 agent가 동시에 claim 시도 테스트 (TestChainOwnership)
+- [x] Chain ownership 해제 테스트 (TestChainOwnership)
+
+## 구현 완료 사항
+
+### Migration (0012_chain_ownership.sql)
+1. chains 테이블에 `owner_agent_id` 컬럼 추가
+2. `claim_task()` 함수를 chain ownership 로직으로 재작성:
+   - Agent가 이미 chain을 소유하면 그 chain의 task만 claim
+   - Agent가 chain을 소유하지 않으면 소유되지 않은 chain의 첫 task claim 및 ownership 획득
+3. `check_and_release_chain_ownership()` 헬퍼 함수 추가
+4. Task 완료/실패 시 자동 ownership 해제 trigger
+
+### Go 코드 변경
+1. **model.Chain**: `OwnerAgentID` 필드 추가
+2. **postgres.go**: CreateChain, GetChain, ListChains, UpdateChain에 owner_agent_id 처리 추가
+3. **memory.go**:
+   - ClaimTask: chain ownership 체크 로직 추가
+   - checkAndReleaseChainOwnership: 헬퍼 함수 구현
+   - CompleteTask/FailTask: ownership 해제 로직 호출
+   - UpdateChain: OwnerAgentID 업데이트 지원
+4. **memory_test.go**: TestChainOwnership 테스트 케이스 추가
+
+## 최종 구현 상태
+
+### ✅ 완료된 기능
+1. **Chain Ownership 시스템**
+   - Agent는 동시에 하나의 Chain만 소유
+   - Chain 첫 task claim 시 자동 ownership 획득
+   - 소유한 Chain의 task만 claim 가능
+   - 다른 agent는 소유된 chain에 접근 불가
+
+2. **Locked 상태 시스템**
+   - Detach 시 chain과 in_progress task를 `locked` 상태로 전환
+   - Locked task는 `queued` 또는 `done`으로만 전환 가능
+   - Locked chain은 새로운 claim 차단
+
+3. **수동 Detach API**
+   - `POST /v1/chains/{id}/detach`
+   - `POST /v1/tasks/{id}/status` (locked task 상태 변경)
+   - `POST /v1/chains/{id}/assign-agent` (ownership 재할당)
+
+4. **자동 해제 제거**
+   - Task 완료/실패 시 ownership 유지
+   - Chain status만 업데이트 (ownership 보존)
+
+### 📊 테스트 커버리지
+- ✅ TestChainOwnership: 기본 ownership 동작
+- ✅ TestDetachAgentFromChain: Detach 및 locked 상태
+- ✅ TestUpdateTaskStatus: Locked task 상태 전환
+- ✅ TestClaimTaskBlockedByLockedTask: Locked chain claim 차단
+
+### 🔧 검증 필요 사항
+- [ ] Postgres migration 실행 및 동작 확인
+- [ ] UI에서 chain owner_agent_id, locked 상태 표시 확인
+- [ ] 실제 agent로 detach 시나리오 테스트
+
+## 변경 파일
+- `supabase/migrations/0012_chain_ownership.sql` (신규)
+- `coordinator/internal/model/model.go`
+- `coordinator/internal/store/postgres/postgres.go`
+- `coordinator/internal/store/memory/memory.go`
+- `coordinator/internal/store/postgres/postgres_test.go`
+- `coordinator/internal/store/memory/memory_test.go`
+
+## 설계 노트
+
+### claim_task 함수 로직 (의사코드)
+```sql
+-- 1. Agent가 이미 소유한 chain이 있는지 확인
+SELECT owner_chain_id FROM agents WHERE id = agent_id;
+
+-- 2-a. 소유한 chain이 있으면, 그 chain의 다음 queued task만 claim 가능
+IF owner_chain_id IS NOT NULL THEN
+  SELECT task FROM tasks
+  WHERE chain_id = owner_chain_id
+    AND status = 'queued'
+    AND sequence = (next sequential task)
+  FOR UPDATE SKIP LOCKED;
+
+-- 2-b. 소유한 chain이 없으면, queued chain의 첫 task를 claim하고 ownership 획득
+ELSE
+  SELECT task FROM tasks
+  WHERE chain_id IN (SELECT id FROM chains WHERE status = 'queued' AND owner_agent_id IS NULL)
+    AND sequence = 1
+  FOR UPDATE SKIP LOCKED;
+
+  UPDATE chains SET owner_agent_id = agent_id WHERE id = task.chain_id;
+END IF;
+```
+
+### Ownership 해제 조건
+- Chain의 모든 task가 `done` 상태일 때
+- Chain의 어떤 task가 `failed` 상태일 때 (정책에 따라 다를 수 있음)
+- Agent가 명시적으로 detach API를 호출할 때

--- a/tasks/0047-detach-agent-locked-task.md
+++ b/tasks/0047-detach-agent-locked-task.md
@@ -1,0 +1,31 @@
+# Detach Agent & Locked Task Feature
+
+## 요구사항
+- REQUIREMENTS.md 참조: Agent Detach & Locked Task Resolution
+
+## 작업 목록
+- [x] Add `locked` status constants to model
+- [x] Add store interface methods (DetachAgentFromChain, UpdateTaskStatus)
+- [x] Implement memory store methods
+- [x] Add memory store tests
+- [x] Implement postgres store methods
+- [x] Add postgres store tests
+- [x] Create DB migration
+- [x] Add HTTP handlers (detach, task status update, assign-agent)
+- [x] Register routes
+- [x] Update dashboard UI (app.js)
+- [x] Add CSS styles
+- [x] Run tests
+
+## 변경 파일
+- `coordinator/internal/model/model.go`
+- `coordinator/internal/store/store.go`
+- `coordinator/internal/store/memory/memory.go`
+- `coordinator/internal/store/memory/memory_test.go`
+- `coordinator/internal/store/postgres/postgres.go`
+- `coordinator/internal/store/postgres/postgres_test.go`
+- `coordinator/internal/httpapi/handlers.go`
+- `coordinator/internal/httpapi/server.go`
+- `coordinator/internal/httpapi/ui/app.js`
+- `coordinator/internal/httpapi/ui/styles.css`
+- `supabase/migrations/0013_locked_status.sql`

--- a/tasks/0048-notification-setup-waiting.md
+++ b/tasks/0048-notification-setup-waiting.md
@@ -1,0 +1,25 @@
+# Notification System for Setup Waiting Agents
+
+## 요구사항
+- REQUIREMENTS.md 참조: Agent가 setup_waiting 상태일 때 대시보드에 알림 표시
+- SSE 기반 실시간 알림 → 사용자에게 "Claude Code 백그라운드 실행" yes/no 프롬프트
+
+## 작업 목록
+- [x] bus.go: busEvent에 Payload 필드 추가, EventNotification 상수, PublishWithPayload 메서드
+- [x] notifications.go (신규): 알림 중복 방지 tracker (에이전트별 5분 cooldown)
+- [x] handlers.go: heartbeat에서 setup_waiting 감지 → 알림 발송
+- [x] handlers.go: SSE에서 notification 이벤트 분리
+- [x] server.go: notificationTracker 추가, dismiss 엔드포인트 등록
+- [x] handlers.go: dismiss API 핸들러
+- [x] dashboard.html: 알림 벨 버튼 + 알림 패널 HTML
+- [x] styles.css: 플로팅 벨, 패널, 알림 아이템 스타일
+- [x] app.js: SSE notification 리스너, 알림 상태관리, 렌더링, yes/no 액션
+
+## 변경 파일
+- `coordinator/internal/httpapi/bus.go`
+- `coordinator/internal/httpapi/notifications.go` (신규)
+- `coordinator/internal/httpapi/server.go`
+- `coordinator/internal/httpapi/handlers.go`
+- `coordinator/internal/httpapi/ui/dashboard.html`
+- `coordinator/internal/httpapi/ui/styles.css`
+- `coordinator/internal/httpapi/ui/app.js`

--- a/tasks/0049-request-session-token-completion.md
+++ b/tasks/0049-request-session-token-completion.md
@@ -1,0 +1,13 @@
+# 0049 Request Session Token Completion
+
+## Goal
+- `request_claude_session` 완료를 일반 태스크 완료와 분리하고, `agent_session_request_token` 기반으로 정확한 세션 요청 태스크를 `done` 처리한다.
+
+## Checklist
+- [x] `REQUIREMENTS.md`에 전용 이벤트 + 토큰 기반 완료 요구사항 추가
+- [x] Coordinator가 세션 요청 태스크 생성 시 `agent_session_request_token` 발급/저장
+- [x] Agent가 세션 할당 완료 시 전용 이벤트(`agent.automation.session_request.completed`) 전송
+- [x] 전용 이벤트 payload에 `agent_session_request_token` 포함
+- [x] Coordinator가 토큰으로 세션 요청 태스크를 찾아 `done` 처리
+- [x] Postgres 스키마/마이그레이션에 `agent_session_request_token` 컬럼 및 unique 인덱스 추가
+- [x] 관련 핸들러 테스트 추가

--- a/tasks/0050-session-request-completion-hardening.md
+++ b/tasks/0050-session-request-completion-hardening.md
@@ -1,0 +1,11 @@
+# 0050 Session Request Completion Hardening
+
+## Goal
+- `agent.automation.session_request.completed` 처리에서 토큰 키 중복을 제거하고, 서버가 이벤트를 받았을 때 세션 요청 task를 확실히 `done` 처리하도록 보강한다.
+
+## Checklist
+- [x] `REQUIREMENTS.md`에 canonical 토큰 키/오류 반환 정책 반영
+- [x] Agent 전송 payload에서 토큰 키를 `agent_session_request_token` 하나로 정리
+- [x] Coordinator가 `task_id` + 토큰 조합으로 대상 task 식별 가능하도록 보강
+- [x] 전용 완료 처리에서 상태 전이 실패를 조용히 무시하지 않도록 수정
+- [x] 관련 핸들러 테스트 보강

--- a/tasks/0051-fix-subscription-inline-edit-focus-and-save.md
+++ b/tasks/0051-fix-subscription-inline-edit-focus-and-save.md
@@ -1,0 +1,15 @@
+# Subscription 인라인 편집 포커스/저장 UX 수정
+
+## 배경
+- 대시보드 Agent 테이블의 `subscriptions` 인라인 편집에서 Enter, Esc, blur 동작 후 input 포커스가 해제되지 않거나 저장 여부를 알기 어려운 문제가 있음.
+
+## 작업 항목
+- [x] 기존 인라인 편집 로직 분석 및 포커스 고착 원인 확인
+- [x] Enter/blur 저장, Esc 취소, 포커스 해제 동작을 일관되게 수정
+- [x] 저장 상태(saving/saved/error) 표시 추가
+- [x] 문서(`REQUIREMENTS.md`) 요구사항 반영
+- [x] 변경 확인 및 체크리스트 완료 처리
+
+## 변경 파일
+- `coordinator/internal/httpapi/ui/app.js`
+- `REQUIREMENTS.md`

--- a/tasks/0053-fix-agent-dashboard-manual-channel-apply.md
+++ b/tasks/0053-fix-agent-dashboard-manual-channel-apply.md
@@ -1,0 +1,21 @@
+# 에이전트 대시보드 수동 채널 입력 적용 점검/수정
+
+## 배경
+- 에이전트 대시보드에서 subscriptions(채널) 직접 입력 시 기대한 대로 적용되지 않는 이슈가 보고됨.
+
+## 작업 항목
+- [x] 대시보드 subscriptions 인라인 편집 저장 경로(UI → API) 점검
+- [x] 서버 채널 구독 업데이트 및 후속 동작(request-session/worker polling) 불일치 원인 확인
+- [x] 직접 입력 채널 적용 실패 케이스 수정
+- [x] 관련 테스트/검증 수행 및 결과 기록
+- [x] 체크리스트 완료 처리
+
+## 변경 파일
+- `coordinator/internal/httpapi/ui/app.js`
+- `agent/clw-agent.js`
+- `tasks/0053-fix-agent-dashboard-manual-channel-apply.md`
+- `tasks/INDEX.md`
+
+## 구현 메모
+- subscriptions 편집 UI를 채널 목록 단일 드롭다운으로 변경했다.
+- 드롭다운 선택 변경(`change`) 즉시 `PATCH /v1/agents/{id}/channels` 요청을 전송하도록 수정했다.

--- a/tasks/0054-enforce-chain-assign-subscription-check.md
+++ b/tasks/0054-enforce-chain-assign-subscription-check.md
@@ -1,0 +1,21 @@
+# 체인 할당 시 채널 구독 검증 + 구독 추가 확인 플로우
+
+## 배경
+- 체인에 Agent를 수동 할당할 때, Agent의 `subscriptions`에 체인 채널이 없어도 그대로 할당되는 문제가 있다.
+- 운영자 UX 기준으로는 미구독 상태를 즉시 막고, 필요 시 UI에서 구독 추가를 승인한 뒤 재할당할 수 있어야 한다.
+
+## 작업 항목
+- [x] `REQUIREMENTS.md`에 체인 할당 시 구독 검증/프론트 후속 플로우 요구사항 반영
+- [x] 백엔드 `POST /v1/chains/{id}/assign-agent`에 채널 구독 검증 추가 및 명시적 오류 코드 반환
+- [x] 프론트 체인 할당 드롭다운에서 구독 오류 시 “채널 구독 추가 여부” 확인 UX 추가
+- [x] 사용자가 승인하면 `PATCH /v1/agents/{id}/channels`로 채널 구독 추가 후 체인 할당 재시도
+- [x] 핸들러 테스트 추가 및 관련 테스트 실행
+- [x] 체크리스트 완료 처리
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `coordinator/internal/httpapi/handlers.go`
+- `coordinator/internal/httpapi/handlers_test.go`
+- `coordinator/internal/httpapi/ui/app.js`
+- `tasks/0054-enforce-chain-assign-subscription-check.md`
+- `tasks/INDEX.md`

--- a/tasks/INDEX.md
+++ b/tasks/INDEX.md
@@ -24,3 +24,4 @@
 - `0020-acceptance-test-runbook.md` — **Done** — 로컬 실행/화면 확인/인수테스트 절차 문서화
 - `0021-interactive-prompts.md` — **Done** — 인터랙티브 선택지 감지 → 대시보드 표시 → 사용자 선택/주입
 - `0022-interactive-prompt-navigation.md` — **Done** — Enter/Tab/Arrow/Esc 기반 선택지 UI 감지 + 키 주입(옵션 선택)
+- `0054-enforce-chain-assign-subscription-check.md` — **Done** — 체인 수동 할당 시 채널 구독 검증 + UI 구독 추가 확인/재시도


### PR DESCRIPTION
## 핵심 요약 (Key Summary)

Chain 소유권 시스템, Locked 상태 메커니즘 및 UI 개선

## 작업 사항 (Work Done)

### 1. Agent-Channel 구독 검증 시스템
- Agent가 구독하지 않은 채널의 Task를 claim하지 못하도록 검증 로직 추가
- `ClaimTask` API에서 Agent의 채널 구독 여부 확인
- 관련 커밋: `5d23456`, `fd9c9c1`

### 2. Chain Ownership 독점성 시스템
- Agent는 동시에 하나의 Chain만 소유 가능하도록 제한
- Chain 소유 중인 Agent는 다른 Chain의 Task를 claim할 수 없음
- Chain을 소유한 Agent만 해당 Chain의 Task를 claim 가능
- Ownership 해제 메커니즘 (수동 detach 지원)
- 관련 커밋: `869a792`, `ff7cbbc`

### 3. Locked Status 메커니즘
- Agent가 `in_progress` 상태의 Task를 수행 중 detach 시 `locked` 상태로 전환
- Task/Chain 상태에 `locked` 추가 (`queued`/`in_progress`/`done`/`failed`/`locked`)
- UI에서 Locked Task를 수동으로 `Done` 또는 `Queued`로 변경 가능
- 관련 커밋: `869a792`, `59d5d72`, `8861205`

### 4. UI 개선
- Channel input focusing 문제 해결 (`818ef4c`, `bfb8fc3`, `08ff752`)
- Agent attach/detach 드롭다운 및 버튼 추가 (`ff7cbbc`)
- Chain-Agent, Chain-Channel 뷰 변경 (`323a15d`)
- Lock 상태 UI 표시 및 상태 변경 버튼 추가 (`59d5d72`)
- Agent 재렌더링 시 채널 초기화 문제 해결 (`bfb8fc3`, `08ff752`)

### 5. 멀티테넌시 강화
- Task는 반드시 Chain에 속해야 함 (Chain ID 필수)
- Chain 소유권 독점성 보장
- Agent별 구독 채널 격리

## 변경 사항 (Changes)

### 데이터베이스 변경
- Task/Chain에 `locked` 상태 추가
- Session request token 컬럼 추가
- Chain ownership 관련 제약조건 강화

### 동작 변경
- **Chain 독점성**: Agent는 하나의 Chain만 소유 가능 (이전: 제한 없음)
- **구독 검증**: 구독하지 않은 채널의 Task claim 불가 (이전: 검증 없음)
- **Detach 시 Lock**: in_progress Task가 자동으로 locked 전환 (이전: queued 복귀)
