### PR TITLE
fix: 태스크 시퀀스 자동 계산 및 체인 claim 조건 완화

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -43,6 +43,11 @@
 - 채널(도메인) 단위로 태스크 발행
 - 채널별 태스크 목록/상태 표시
 - 태스크 상태 최소 단계: `Queued / In Progress / Done`
+- 채널 보드 헤더에는 해당 채널의 **Task 수가 아닌 Chain 수**를 표시해야 한다.
+- 체인 카드는 기본적으로 헤더(체인 이름/상태/할당 정보) 중심으로 표시하고, 체인에 속한 태스크 보드는 접기/펼치기(toggle) 가능해야 한다.
+- `Channel:{name}` 헤더 우측에 `새 체인` 버튼을 두고, 클릭 시 작은 popover에서 체인 이름을 입력해 생성할 수 있어야 한다.
+- 각 체인의 `Queued` 컬럼 헤더 우측에는 `+` 버튼을 두고, 작은 popover에서 Task 제목을 입력해 생성할 수 있어야 한다.
+- `Queued` 컬럼의 popover로 Task 생성 시 `channel_id`와 `chain_id`는 해당 카드 컨텍스트를 자동 사용해야 하며, 사용자가 별도로 입력하지 않아야 한다.
 
 ### 4.4 태스크 분배 모델
 - 분배 방식: **FIFO**
@@ -58,11 +63,13 @@
 - **독점적 접근**: Chain을 소유한 Agent만 해당 Chain의 Task를 claim할 수 있다. 같은 채널을 구독하는 다른 Agent는 소유된 Chain의 Task를 claim할 수 없다
 - **Ownership 해제**: Chain의 모든 Task가 완료되거나 실패하면 소유권이 자동으로 해제된다
 - **Detach 메커니즘**: Agent는 명시적으로 Chain ownership을 해제할 수 있다 (수동 detach)
+- **후속 Task claim 게이트**: Chain에서 다음 Task를 `in_progress`로 올릴 때, 현재 Task보다 선행(sequence가 더 작은) Task들 중 `queued` 또는 `in_progress` 상태가 하나도 없으면 claim 가능하다 (`done`/`failed`는 블로킹하지 않음).
 
 #### 4.4.2 Detach 및 Locked Task 처리
 - **Detach 동작**: Agent를 Chain에서 분리하면 현재 `in_progress` 상태인 Task는 `locked` 상태로 전환된다
   - Chain의 `owner_agent_id`가 초기화된다
-  - Chain 상태가 `locked`로 변경된다
+  - `locked` Task가 존재하면 Chain 상태는 `locked`로 변경된다
+  - `in_progress` Task가 없어 `locked` Task가 생기지 않으면 Chain 상태는 남은 Task 상태(`queued`/`in_progress`/`done`/`failed`)로 재평가된다
   - Agent의 `current_task_id`가 초기화된다
 - **Locked 상태**: Task/Chain이 Agent 분리로 인해 중단된 상태를 나타내는 새로운 상태값
   - Task 상태: `queued` / `in_progress` / `done` / `failed` / **`locked`**

--- a/coordinator/internal/httpapi/ui/styles.css
+++ b/coordinator/internal/httpapi/ui/styles.css
@@ -148,11 +148,60 @@ input::placeholder { color: rgba(169,175,191,0.65); }
   border-radius: 12px;
   padding: 14px;
 }
-.channel-group > .col-title {
+.channel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+.channel-label {
   font-size: 14px;
   font-weight: 600;
-  color: var(--fg);
-  margin-bottom: 12px;
+}
+.channel-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.chain-create-wrap {
+  position: relative;
+}
+.chain-create-btn {
+  height: 30px;
+  padding: 5px 10px;
+  font-size: 12px;
+}
+.chain-create-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 230px;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(17,21,34,0.96);
+  box-shadow: var(--shadow);
+  z-index: 6;
+}
+.chain-create-popover.hidden {
+  display: none;
+}
+.chain-create-input {
+  height: 34px;
+  margin-bottom: 8px;
+}
+.chain-create-popover-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.chain-create-confirm,
+.chain-create-cancel {
+  height: 32px;
+  padding: 6px 8px;
+  font-size: 12px;
 }
 .chain-group {
   margin-bottom: 12px;
@@ -168,6 +217,8 @@ input::placeholder { color: rgba(169,175,191,0.65); }
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
   margin-bottom: 8px;
 }
 .chain-title strong { font-weight: 700; }
@@ -197,6 +248,14 @@ input::placeholder { color: rgba(169,175,191,0.65); }
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 14px;
+}
+.chain-board-collapsed {
+  display: none;
+}
+.chain-toggle-btn {
+  height: 28px;
+  padding: 4px 10px;
+  font-size: 11px;
 }
 .col {
   background: var(--panel2);
@@ -228,6 +287,45 @@ input::placeholder { color: rgba(169,175,191,0.65); }
   justify-content: space-between;
   align-items: center;
   margin-bottom: 10px;
+}
+.col-title-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.queued-task-create-wrap {
+  position: relative;
+}
+.queued-task-create-btn {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  font-size: 16px;
+  line-height: 1;
+}
+.queued-task-create-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 220px;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(17,21,34,0.96);
+  box-shadow: var(--shadow);
+  z-index: 7;
+}
+.queued-task-create-popover.hidden {
+  display: none;
+}
+.queued-task-create-input {
+  height: 34px;
+  margin-bottom: 8px;
+}
+.queued-task-create-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
 }
 .pill { font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border); color: var(--muted); }
 .task {
@@ -342,6 +440,9 @@ input::placeholder { color: rgba(169,175,191,0.65); }
   .row { grid-template-columns: 1fr; }
   .task-row { grid-template-columns: 1fr; }
   .topbar-actions { justify-content: flex-start; }
+  .channel-actions { width: 100%; justify-content: flex-end; }
+  .chain-create-popover { left: 0; right: auto; width: min(280px, calc(100vw - 80px)); }
+  .queued-task-create-popover { left: 0; right: auto; width: min(260px, calc(100vw - 110px)); }
 }
 
 @media (max-width: 900px) {

--- a/tasks/0052-fix-chain-owner-claim-rules.md
+++ b/tasks/0052-fix-chain-owner-claim-rules.md
@@ -1,0 +1,20 @@
+# 체인 소유자 claim 규칙 보정 (detach/lease 전 소유 고정)
+
+## 배경
+- 체인 소유자가 `detach` 전까지(또는 lease 만료 전까지) 유지되어야 하는데, 상태(`in_progress`) 기반 필터로 인해 소유 체인 인식이 깨지는 문제가 있음.
+- 소유 체인에 새 Task가 추가됐을 때 기존 소유자가 독점 claim해야 하는데, 체인 상태 필터 때문에 claim되지 않는 경우가 발생함.
+
+## 작업 항목
+- [x] `REQUIREMENTS.md`에 완료/실패 후 ownership 유지 및 신규 Task claim 규칙 명시
+- [x] 메모리 스토어 `ClaimTask`의 체인 소유 인식/후보 선정 조건 수정
+- [x] Postgres `claim_task()` 함수(마이그레이션)에서 동일 규칙 반영
+- [x] 회귀 테스트 추가/수정 (소유 체인 신규 Task claim 시나리오)
+- [x] 체크리스트 완료 처리
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `coordinator/internal/store/memory/memory.go`
+- `coordinator/internal/store/memory/memory_test.go`
+- `supabase/migrations/0012_chain_ownership.sql`
+- `supabase/migrations/0015_fix_claim_task_owner_persistence.sql`
+- `tasks/INDEX.md`

--- a/tasks/0055-fix-subscription-dropdown-edit-refresh-race.md
+++ b/tasks/0055-fix-subscription-dropdown-edit-refresh-race.md
@@ -1,0 +1,21 @@
+# Agent 대시보드 Subscription 드롭다운 편집 안정화
+
+## 배경
+- Agent 대시보드 Subscription 드롭다운이 편집 중 자동 갱신과 충돌해 정상 동작하지 않는 문제가 보고됨.
+- 본 작업은 `REQUIREMENTS.md`의 `4.10 UI 기반 에이전트 채널 할당` 요구사항 이행 품질을 보강한다.
+
+## 작업 항목
+- [x] Subscription 드롭다운 편집 중 리렌더 경합 원인 확인
+- [x] 편집 중(`select`) 상태에서는 Agent 테이블 리렌더를 건너뛰도록 수정
+- [x] 편집 진입 가드(중복 편집 방지) 보강
+- [x] 동작 검증 및 task 체크리스트 완료 처리
+
+## 변경 파일
+- `coordinator/internal/httpapi/ui/app.js`
+- `tasks/0055-fix-subscription-dropdown-edit-refresh-race.md`
+- `tasks/INDEX.md`
+
+## 구현 메모
+- 원인: Agent 테이블 리렌더 스킵 조건이 `input` 편집만 고려하고 있어, 실제 `select` 드롭다운 편집 중에는 auto refresh/SSE 리렌더로 편집 UI가 끊겼다.
+- 수정: `renderAgents()`의 편집 감지를 `.subs-cell select, .subs-cell input`으로 확장해 드롭다운 편집 중 리렌더를 건너뛰도록 했다.
+- 보강: Subscription 셀 클릭 시 중복 편집 진입 가드를 `select`까지 포함하도록 변경했다.

--- a/tasks/0056-fix-memory-store-chain-ownership-bypass.md
+++ b/tasks/0056-fix-memory-store-chain-ownership-bypass.md
@@ -1,0 +1,16 @@
+# Fix: Memory Store Chain Ownership Bypass After Completion
+
+## 요구사항
+- 에이전트는 최대 하나의 체인만 소유 가능
+- 체인의 모든 태스크 완료 후에도 명시적 detach 전까지 소유권 유지
+- Memory Store와 Postgres Store 동작 일치
+
+## 작업 목록
+- [x] Memory Store ClaimTask 소유권 체크에서 status 필터 제거
+- [x] eligible task 필터링에서 소유 체인 done 상태 처리
+- [x] reevaluateChainStatus에서 체인 완료 시 OwnerAgentID 자동 해제 제거
+- [x] CreateTask에서 reevaluateChainStatus 호출 추가
+- [x] 빌드 확인
+
+## 변경 파일
+- `coordinator/internal/store/memory/memory.go`

--- a/tasks/0057-fix-chain-task-sequence-auto-calc.md
+++ b/tasks/0057-fix-chain-task-sequence-auto-calc.md
@@ -1,0 +1,12 @@
+# Fix: 기존 체인에 태스크 추가 시 sequence 미설정으로 claim 불가 버그
+
+## 요구사항
+- REQUIREMENTS.md 참조: 체인 태스크 관리
+
+## 작업 목록
+- [x] 서버 핸들러에서 sequence 자동 계산 로직 추가
+- [x] Postgres Store CreateTask 후 done 체인 상태를 queued로 복원
+
+## 변경 파일
+- `coordinator/internal/httpapi/handlers.go` - sequence 자동 계산 로직
+- `coordinator/internal/store/postgres/postgres.go` - CreateTask 후 chain status 업데이트

--- a/tasks/0058-fix-detach-lock-condition-without-inprogress.md
+++ b/tasks/0058-fix-detach-lock-condition-without-inprogress.md
@@ -1,0 +1,20 @@
+# Fix: Detach 시 in_progress 없음에도 Chain이 locked 되는 문제
+
+## 요구사항
+- REQUIREMENTS.md 참조: 4.4.2 Detach 및 Locked Task 처리
+- detach 시 `in_progress` Task가 `locked`로 전환된 경우에만 Chain을 `locked`로 둔다
+- detach 시 `in_progress` Task가 없으면 Chain 상태를 Task 집합 기준으로 재평가한다
+
+## 작업 목록
+- [x] REQUIREMENTS.md 조건 문구 보강
+- [x] Memory Store detach 상태 전환 로직 수정
+- [x] Postgres Store detach 상태 전환 로직 수정
+- [x] Memory/Postgres 회귀 테스트 추가
+- [x] 관련 테스트 실행
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `coordinator/internal/store/memory/memory.go`
+- `coordinator/internal/store/memory/memory_test.go`
+- `coordinator/internal/store/postgres/postgres.go`
+- `coordinator/internal/store/postgres/postgres_test.go`

--- a/tasks/0059-relax-chain-claim-gate-for-failed-predecessors.md
+++ b/tasks/0059-relax-chain-claim-gate-for-failed-predecessors.md
@@ -1,0 +1,21 @@
+# Fix: failed 선행 Task가 있어도 다음 Task claim 가능하도록 체인 게이트 완화
+
+## 요구사항
+- REQUIREMENTS.md 참조: 4.4.1 Chain Ownership 및 독점성
+- 다음 Task를 `in_progress`로 올리는 조건을 "선행 Task 중 `queued`/`in_progress` 없음"으로 변경
+- `done`/`failed` 선행 Task는 claim 블로킹 조건에서 제외
+- Memory/Postgres 동작 일치
+
+## 작업 목록
+- [ ] REQUIREMENTS.md에 새 claim 게이트 규칙 명시
+- [ ] Memory Store ClaimTask 선행 조건 로직 수정
+- [ ] Postgres claim_task 함수 갱신(신규 migration 추가)
+- [ ] Memory/Postgres 회귀 테스트 추가/수정
+- [ ] 관련 테스트 실행
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `coordinator/internal/store/memory/memory.go`
+- `coordinator/internal/store/memory/memory_test.go`
+- `supabase/migrations/0016_relax_chain_claim_gate_for_failed_predecessors.sql`
+- `coordinator/internal/store/postgres/postgres_test.go`

--- a/tasks/0060-ui-chain-collapse-and-create-popover.md
+++ b/tasks/0060-ui-chain-collapse-and-create-popover.md
@@ -1,0 +1,25 @@
+# UI: 채널 보드 체인 접기/펼치기 + 체인 생성 팝오버
+
+## 요구사항
+- REQUIREMENTS.md 참조: 4.3 작업 태스크 보드
+- 채널 헤더 보조 지표를 task 개수에서 chain 개수로 변경
+- 체인 카드에서 태스크 보드를 접기/펼치기(toggle) 지원
+- 채널 헤더 우측 `새 체인` 버튼 + popover 입력으로 체인 생성 지원
+- 체인의 `Queued` 컬럼 헤더 우측 `+` 버튼 + popover 입력으로 task 생성 지원
+- `Queued` popover에서 생성한 task는 해당 chain/channel 컨텍스트로 자동 등록
+
+## 작업 목록
+- [x] 대시보드 체인 렌더링 UI에 접기/펼치기 상태 추가
+- [x] 채널 헤더 보조 지표를 chain 개수로 변경
+- [x] 채널 헤더에 체인 생성 popover UI 추가
+- [x] `/v1/chains` 호출로 체인 생성 이벤트/검증 처리
+- [x] 체인 Queued 컬럼 헤더에 task 생성 popover UI 추가
+- [x] `/v1/tasks` 호출 시 chain/channel 컨텍스트 자동 주입 처리
+- [x] UI 스타일 반영 및 반응형 점검
+- [ ] 변경 동작 수동 검증
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `tasks/0060-ui-chain-collapse-and-create-popover.md`
+- `coordinator/internal/httpapi/ui/app.js`
+- `coordinator/internal/httpapi/ui/styles.css`

--- a/tasks/INDEX.md
+++ b/tasks/INDEX.md
@@ -25,3 +25,4 @@
 - `0021-interactive-prompts.md` — **Done** — 인터랙티브 선택지 감지 → 대시보드 표시 → 사용자 선택/주입
 - `0022-interactive-prompt-navigation.md` — **Done** — Enter/Tab/Arrow/Esc 기반 선택지 UI 감지 + 키 주입(옵션 선택)
 - `0054-enforce-chain-assign-subscription-check.md` — **Done** — 체인 수동 할당 시 채널 구독 검증 + UI 구독 추가 확인/재시도
+- `0055-fix-subscription-dropdown-edit-refresh-race.md` — **Done** — Agent subscription 드롭다운 편집 중 auto refresh 리렌더 경합 수정


### PR DESCRIPTION
## 요약
1. 동일한 체인에 Done 상태인 작업이 하나 있는경우 새로운 작업을 생성하여도 claim 해가지 않던 오류 해결( #34 )

2. 사용자 편의 UI 요소 추가( #35 )
- 체인 접기/펼치기
- 작업 + 버튼

## 주요 변경사항

1. **태스크 시퀀스 번호 자동 계산**: UI에서 시퀀스 번호를 전달하지 않을 때 서버에서 자동으로 다음 번호 계산
4. **체인 claim 조건 완화**: 선행 태스크가 done 또는 failed 상태일 때 다음 태스크를 claim 할 수 있도록 수정 (기존에는 done만 허용)
5. **UI 개선**: 체인 접기/펼치기 기능 추가 및 새 체인, 새 태스크 생성 팝오버 버튼 구현
