### PR TITLE
fix: UI 안정성 적용 - 사용자 타이핑시 포커스 유지, 에이전트 대시보드 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ yarn-error.log*
 
 .gemini/
 gha-creds-*.json
+
+.gocache/**

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -36,7 +36,9 @@
 ### 4.2 웹뷰 대시보드 (배포형)
 - 인터넷에서 접근 가능한 웹 UI 제공
 - 현재 활성 에이전트 수 표시
+- 에이전트 목록 응답(`GET /v1/agents`, `GET /v1/dashboard`)은 기본적으로 에이전트 이름 오름차순으로 정렬되어야 한다. (리렌더링 시 순서 안정성)
 - 에이전트별 상태 및 현재 작업 표시
+- Worker 상태가 `offline`이면 Claude 상태는 `not running`으로 표시되어야 하며, API에서는 `claude_status=idle`로 정규화되어야 한다.
 - 에이전트별 작업 이력(타임라인) 표시
 
 ### 4.3 작업 태스크 보드 (Jira 유사, 최소 기능)
@@ -48,6 +50,7 @@
 - `Channel:{name}` 헤더 우측에 `새 체인` 버튼을 두고, 클릭 시 작은 popover에서 체인 이름을 입력해 생성할 수 있어야 한다.
 - 각 체인의 `Queued` 컬럼 헤더 우측에는 `+` 버튼을 두고, 작은 popover에서 Task 제목을 입력해 생성할 수 있어야 한다.
 - `Queued` 컬럼의 popover로 Task 생성 시 `channel_id`와 `chain_id`는 해당 카드 컨텍스트를 자동 사용해야 하며, 사용자가 별도로 입력하지 않아야 한다.
+- 체인/Queued popover 입력 중 auto refresh(SSE/poll)로 인한 리렌더가 발생해도 입력 draft와 focus가 끊기지 않아야 한다.
 
 ### 4.4 태스크 분배 모델
 - 분배 방식: **FIFO**

--- a/coordinator/internal/httpapi/agent_status.go
+++ b/coordinator/internal/httpapi/agent_status.go
@@ -1,0 +1,23 @@
+package httpapi
+
+import (
+	"time"
+
+	"clwclw-monitor/coordinator/internal/model"
+)
+
+func agentWithDerivedRuntimeStatus(a model.Agent, threshold time.Duration) agentResponse {
+	workerStatus := a.DerivedWorkerStatus(threshold)
+	effective := a
+
+	// If worker is offline, Claude process cannot be running.
+	if workerStatus == model.WorkerStatusOffline {
+		effective.ClaudeStatus = model.ClaudeStatusIdle
+		effective.Status = model.AgentStatusIdle
+	}
+
+	return agentResponse{
+		Agent:        effective,
+		WorkerStatus: workerStatus,
+	}
+}

--- a/coordinator/internal/httpapi/agent_status_test.go
+++ b/coordinator/internal/httpapi/agent_status_test.go
@@ -1,0 +1,48 @@
+package httpapi
+
+import (
+	"testing"
+	"time"
+
+	"clwclw-monitor/coordinator/internal/model"
+)
+
+func TestAgentWithDerivedRuntimeStatus_OfflineForcesIdle(t *testing.T) {
+	threshold := 30 * time.Second
+	agent := model.Agent{
+		Status:       model.AgentStatusRunning,
+		ClaudeStatus: model.ClaudeStatusRunning,
+		LastSeen:     time.Now().UTC().Add(-31 * time.Second),
+	}
+
+	got := agentWithDerivedRuntimeStatus(agent, threshold)
+	if got.WorkerStatus != model.WorkerStatusOffline {
+		t.Fatalf("expected worker offline, got %q", got.WorkerStatus)
+	}
+	if got.ClaudeStatus != model.ClaudeStatusIdle {
+		t.Fatalf("expected claude status idle when worker offline, got %q", got.ClaudeStatus)
+	}
+	if got.Status != model.AgentStatusIdle {
+		t.Fatalf("expected legacy status idle when worker offline, got %q", got.Status)
+	}
+}
+
+func TestAgentWithDerivedRuntimeStatus_OnlineKeepsClaudeStatus(t *testing.T) {
+	threshold := 30 * time.Second
+	agent := model.Agent{
+		Status:       model.AgentStatusRunning,
+		ClaudeStatus: model.ClaudeStatusRunning,
+		LastSeen:     time.Now().UTC().Add(-10 * time.Second),
+	}
+
+	got := agentWithDerivedRuntimeStatus(agent, threshold)
+	if got.WorkerStatus != model.WorkerStatusOnline {
+		t.Fatalf("expected worker online, got %q", got.WorkerStatus)
+	}
+	if got.ClaudeStatus != model.ClaudeStatusRunning {
+		t.Fatalf("expected claude status running to be preserved, got %q", got.ClaudeStatus)
+	}
+	if got.Status != model.AgentStatusRunning {
+		t.Fatalf("expected legacy status running to be preserved, got %q", got.Status)
+	}
+}

--- a/coordinator/internal/httpapi/dashboard.go
+++ b/coordinator/internal/httpapi/dashboard.go
@@ -33,10 +33,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	threshold := 30 * time.Second
 	agentResponses := make([]agentResponse, len(agents))
 	for i, a := range agents {
-		agentResponses[i] = agentResponse{
-			Agent:        a,
-			WorkerStatus: a.DerivedWorkerStatus(threshold),
-		}
+		agentResponses[i] = agentWithDerivedRuntimeStatus(a, threshold)
 	}
 
 	channels, err := s.store.ListChannels(r.Context(), userID)

--- a/coordinator/internal/httpapi/handlers.go
+++ b/coordinator/internal/httpapi/handlers.go
@@ -137,10 +137,7 @@ func (s *Server) handleAgentsList(w http.ResponseWriter, r *http.Request) {
 	threshold := 30 * time.Second
 	response := make([]agentResponse, len(agents))
 	for i, a := range agents {
-		response[i] = agentResponse{
-			Agent:        a,
-			WorkerStatus: a.DerivedWorkerStatus(threshold),
-		}
+		response[i] = agentWithDerivedRuntimeStatus(a, threshold)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"agents": response})

--- a/coordinator/internal/httpapi/ui/app.js
+++ b/coordinator/internal/httpapi/ui/app.js
@@ -150,8 +150,8 @@ function deriveWorkerStatus(lastSeen) {
   return age < threshold ? 'online' : 'offline';
 }
 
-function workerStatusBadge(lastSeen) {
-  const status = deriveWorkerStatus(lastSeen);
+function workerStatusBadge(workerStatus, lastSeen) {
+  const status = workerStatus || deriveWorkerStatus(lastSeen);
   const cls = status === 'online' ? 'badge ok' : 'badge err';
   return `<span class="${cls}">${status}</span>`;
 }
@@ -320,7 +320,9 @@ function renderAgents(agents) {
       // Display tmux info: prefer tmux_display (dynamically resolved #S:#I.#P from pane_id)
       const tmux = a?.meta?.tmux_display || a?.meta?.pane_id || a?.meta?.tmux_target || '';
       const workerStatus = a.worker_status ? a.worker_status : deriveWorkerStatus(a.last_seen);
-      const claudeStatus = a.claude_status || a.status || 'idle';
+      const claudeStatus = workerStatus === 'offline'
+        ? 'not running'
+        : (a.claude_status || a.status || 'idle');
       const agentState = a?.meta?.state || '';
       const isSetupWaiting = agentState === 'setup_waiting' && !tmux;
       const hasSubs = Array.isArray(a?.meta?.subscriptions) && a.meta.subscriptions.length > 0;
@@ -343,7 +345,7 @@ function renderAgents(agents) {
 
       return `<tr>
         <td>${escapeHtml(name)}</td>
-        <td>${workerStatusBadge(a.last_seen)}</td>
+        <td>${workerStatusBadge(workerStatus, a.last_seen)}</td>
         <td>${claudeStatusBadge(claudeStatus)}</td>
         <td class="muted subs-cell" data-agent-id="${escapeHtml(a.id)}" data-subs="${escapeHtml(subs)}" title="Click to edit"
             style="cursor:pointer;">${escapeHtml(subs) || '<span class="muted" style="opacity:0.5">click to assign</span>'}</td>

--- a/coordinator/internal/httpapi/ui/app.js
+++ b/coordinator/internal/httpapi/ui/app.js
@@ -267,7 +267,7 @@ async function createChainFromPopover(channelId, rawName) {
   if (created?.chain?.id) {
     expandedChainIds.add(created.chain.id);
   }
-  await refresh();
+  await refresh({ forceTaskBoardRender: true });
 }
 
 function focusQueuedTaskCreateInput(channelId, chainId) {
@@ -298,7 +298,14 @@ async function createTaskFromQueuedPopover(channelId, chainId, rawTitle) {
 
   queuedTaskDraftTitlesByChainId.delete(chainId);
   openQueuedTaskCreateKey = '';
-  await refresh();
+  await refresh({ forceTaskBoardRender: true });
+}
+
+function shouldSkipTaskBoardRender(options = {}) {
+  if (options.forceTaskBoardRender) return false;
+  const active = document.activeElement;
+  if (!active) return false;
+  return !!active.closest?.('.chain-create-input, .queued-task-create-input');
 }
 
 function renderAgents(agents) {
@@ -744,7 +751,7 @@ async function sendPromptKeys(keys, opts = {}) {
   await sendTaskInput('keys', text, false, opts);
 }
 
-async function refresh() {
+async function refresh(options = {}) {
   const dash = await api('/v1/dashboard');
   const agents = dash.agents || [];
   const channels = dash.channels || [];
@@ -767,7 +774,9 @@ async function refresh() {
   fillChannelSelect(els.taskChannel, channels);
   fillChannelSelect(els.claimChannel, channels);
   fillChainSelect(els.taskChain, chains, els.taskChannel.value);
-  renderTaskBoard(channels, chains, tasks, agents);
+  if (!shouldSkipTaskBoardRender(options)) {
+    renderTaskBoard(channels, chains, tasks, agents);
+  }
   renderEvents(events);
 }
 

--- a/coordinator/internal/store/memory/memory.go
+++ b/coordinator/internal/store/memory/memory.go
@@ -119,7 +119,15 @@ func (s *Store) ListAgents(_ context.Context, userID string) ([]model.Agent, err
 	}
 
 	sort.Slice(out, func(i, j int) bool {
-		return out[i].LastSeen.After(out[j].LastSeen)
+		nameI := strings.ToLower(strings.TrimSpace(out[i].Name))
+		nameJ := strings.ToLower(strings.TrimSpace(out[j].Name))
+		if nameI != nameJ {
+			return nameI < nameJ
+		}
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].ID < out[j].ID
 	})
 	return out, nil
 }

--- a/coordinator/internal/store/memory/memory_test.go
+++ b/coordinator/internal/store/memory/memory_test.go
@@ -11,6 +11,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestListAgents_SortedByNameAscending(t *testing.T) {
+	s := NewStore()
+	ctx := context.Background()
+
+	_, err := s.UpsertAgent(ctx, model.Agent{ID: "agent-zeta", Name: "zeta"})
+	assert.NoError(t, err)
+	_, err = s.UpsertAgent(ctx, model.Agent{ID: "agent-beta", Name: "beta"})
+	assert.NoError(t, err)
+	_, err = s.UpsertAgent(ctx, model.Agent{ID: "agent-alpha", Name: "alpha"})
+	assert.NoError(t, err)
+
+	agents, err := s.ListAgents(ctx, "")
+	assert.NoError(t, err)
+	assert.Len(t, agents, 3)
+	assert.Equal(t, "alpha", agents[0].Name)
+	assert.Equal(t, "beta", agents[1].Name)
+	assert.Equal(t, "zeta", agents[2].Name)
+}
+
 func TestCreateChain(t *testing.T) {
 	s := NewStore()
 	ctx := context.Background()

--- a/coordinator/internal/store/postgres/postgres.go
+++ b/coordinator/internal/store/postgres/postgres.go
@@ -131,7 +131,7 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]model.Agent, e
 		query += " where user_id = $1::uuid"
 		args = append(args, userID)
 	}
-	query += " order by last_seen desc"
+	query += " order by lower(name) asc, name asc, id asc"
 
 	rows, err := s.pool.Query(ctx, query, args...)
 	if err != nil {

--- a/coordinator/internal/store/postgres/postgres_test.go
+++ b/coordinator/internal/store/postgres/postgres_test.go
@@ -249,6 +249,26 @@ func setupTestDB(t *testing.T) (*Store, func()) {
 	}
 }
 
+func TestPostgresStore_ListAgents_SortedByNameAscending(t *testing.T) {
+	s, teardown := setupTestDB(t)
+	defer teardown()
+	ctx := context.Background()
+
+	_, err := s.UpsertAgent(ctx, model.Agent{Name: "zeta", Status: model.AgentStatusIdle, ClaudeStatus: model.ClaudeStatusIdle})
+	require.NoError(t, err)
+	_, err = s.UpsertAgent(ctx, model.Agent{Name: "beta", Status: model.AgentStatusIdle, ClaudeStatus: model.ClaudeStatusIdle})
+	require.NoError(t, err)
+	_, err = s.UpsertAgent(ctx, model.Agent{Name: "alpha", Status: model.AgentStatusIdle, ClaudeStatus: model.ClaudeStatusIdle})
+	require.NoError(t, err)
+
+	agents, err := s.ListAgents(ctx, "")
+	require.NoError(t, err)
+	require.Len(t, agents, 3)
+	assert.Equal(t, "alpha", agents[0].Name)
+	assert.Equal(t, "beta", agents[1].Name)
+	assert.Equal(t, "zeta", agents[2].Name)
+}
+
 func TestPostgresStore_ChainCRUD(t *testing.T) {
 	s, teardown := setupTestDB(t)
 	defer teardown()

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,18 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-############################################
-# Config
-############################################
-IMAGE_NAME="${IMAGE_NAME}"
-IMAGE_TAG="${IMAGE_TAG:-latest}"
-PLATFORMS="linux/amd64,linux/arm64"
-DOCKERFILE="../coordinator/Dockerfile"
-BUILD_CONTEXT=".."
 ENV_FILE="../.env.prod"
-
 ############################################
-# 1. Load .env and export variables
+# 0. Load .env and export variables
 ############################################
 if [ ! -f "$ENV_FILE" ]; then
   echo "❌ .env file not found"
@@ -23,6 +14,13 @@ echo "🔐 Loading environment variables from .env"
 set -a
 source "$ENV_FILE"
 set +a
+
+############################################
+# 1. Config
+############################################
+PLATFORMS="linux/amd64,linux/arm64"
+DOCKERFILE="../coordinator/Dockerfile"
+BUILD_CONTEXT=".."
 
 ############################################
 # 2. Docker login (only if not logged in)

--- a/supabase/migrations/0000_full_init.sql
+++ b/supabase/migrations/0000_full_init.sql
@@ -109,6 +109,7 @@ create table if not exists public.tasks (
   title text not null,
   description text null,
   type text null,
+  agent_session_request_token text null,
   status text not null default 'queued',
   priority int not null default 0,
   assigned_agent_id uuid null references public.agents(id) on delete set null,
@@ -124,6 +125,9 @@ create index if not exists idx_tasks_channel_status_created on public.tasks (cha
 create index if not exists idx_tasks_status_created on public.tasks (status, created_at asc);
 create index if not exists idx_tasks_assigned_agent on public.tasks (assigned_agent_id);
 create index if not exists idx_tasks_chain_id on public.tasks (chain_id);
+create unique index if not exists uq_tasks_agent_session_request_token
+on public.tasks (agent_session_request_token)
+where agent_session_request_token is not null;
 
 create trigger trg_tasks_updated_at
 before update on public.tasks

--- a/supabase/migrations/0011_enforce_chain_id.sql
+++ b/supabase/migrations/0011_enforce_chain_id.sql
@@ -1,0 +1,114 @@
+-- 0011_enforce_chain_id.sql
+-- Enforce that all tasks must belong to a chain.
+
+-- Step 1: Auto-create chains for any existing standalone tasks
+DO $$
+DECLARE
+    r RECORD;
+    v_chain_id UUID;
+BEGIN
+    FOR r IN
+        SELECT DISTINCT t.channel_id, t.user_id
+        FROM public.tasks t
+        WHERE t.chain_id IS NULL
+    LOOP
+        INSERT INTO public.chains (channel_id, name, description, status, user_id)
+        VALUES (r.channel_id, 'Migrated Standalone Tasks', 'Auto-created chain for previously standalone tasks', 'queued', r.user_id)
+        RETURNING id INTO v_chain_id;
+
+        UPDATE public.tasks
+        SET chain_id = v_chain_id, sequence = 1
+        WHERE chain_id IS NULL AND channel_id = r.channel_id;
+    END LOOP;
+END;
+$$;
+
+-- Step 2: Make chain_id NOT NULL
+ALTER TABLE public.tasks ALTER COLUMN chain_id SET NOT NULL;
+
+-- Step 3: Change ON DELETE SET NULL to ON DELETE CASCADE
+ALTER TABLE public.tasks DROP CONSTRAINT IF EXISTS tasks_chain_id_fkey;
+ALTER TABLE public.tasks ADD CONSTRAINT tasks_chain_id_fkey
+    FOREIGN KEY (chain_id) REFERENCES public.chains(id) ON DELETE CASCADE;
+
+-- Step 4: Update claim_task function to remove standalone fallback
+DROP FUNCTION IF EXISTS public.claim_task(uuid, uuid);
+
+CREATE OR REPLACE FUNCTION public.claim_task(
+    p_channel_id uuid,
+    p_agent_id uuid
+)
+    RETURNS SETOF public.tasks
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_task_id uuid;
+    v_chain_id uuid;
+BEGIN
+    -- 1. in_progress chain의 다음 task
+    SELECT t.id, t.chain_id
+    INTO v_task_id, v_chain_id
+    FROM public.tasks t
+             JOIN public.chains c ON t.chain_id = c.id
+    WHERE t.channel_id = p_channel_id
+      AND t.status = 'queued'
+      AND c.status = 'in_progress'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.tasks
+        WHERE chain_id = t.chain_id
+          AND sequence < t.sequence
+          AND status != 'done'
+    )
+    ORDER BY c.created_at ASC, t.sequence ASC
+        FOR UPDATE SKIP LOCKED
+    LIMIT 1;
+
+    IF v_task_id IS NOT NULL THEN
+        RETURN QUERY
+            UPDATE public.tasks
+                SET status = 'in_progress',
+                    assigned_agent_id = p_agent_id,
+                    claimed_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = v_task_id
+                RETURNING *;
+
+        RETURN;
+    END IF;
+
+    -- 2. queued chain의 첫 task
+    SELECT t.id, t.chain_id
+    INTO v_task_id, v_chain_id
+    FROM public.tasks t
+             JOIN public.chains c ON t.chain_id = c.id
+    WHERE t.channel_id = p_channel_id
+      AND t.status = 'queued'
+      AND c.status = 'queued'
+      AND t.sequence = 1
+    ORDER BY c.created_at ASC, t.sequence ASC
+        FOR UPDATE SKIP LOCKED
+    LIMIT 1;
+
+    IF v_task_id IS NOT NULL THEN
+        UPDATE public.chains
+        SET status = 'in_progress',
+            updated_at = NOW()
+        WHERE id = v_chain_id;
+
+        RETURN QUERY
+            UPDATE public.tasks
+                SET status = 'in_progress',
+                    assigned_agent_id = p_agent_id,
+                    claimed_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = v_task_id
+                RETURNING *;
+
+        RETURN;
+    END IF;
+
+    -- 아무 것도 못 잡았을 때
+    RETURN;
+END;
+$$;

--- a/supabase/migrations/0012_chain_ownership.sql
+++ b/supabase/migrations/0012_chain_ownership.sql
@@ -1,0 +1,173 @@
+-- 0012_chain_ownership.sql
+-- Add chain ownership to enforce single-chain-per-agent constraint
+
+-- Step 1: Add owner_agent_id to chains table
+ALTER TABLE public.chains ADD COLUMN owner_agent_id UUID REFERENCES public.agents(id) ON DELETE SET NULL;
+
+-- Step 2: Create index for faster ownership lookups
+CREATE INDEX idx_chains_owner_agent_id ON public.chains(owner_agent_id) WHERE owner_agent_id IS NOT NULL;
+
+-- Step 3: Update claim_task function to enforce chain ownership
+DROP FUNCTION IF EXISTS public.claim_task(uuid, uuid);
+
+CREATE OR REPLACE FUNCTION public.claim_task(
+    p_channel_id uuid,
+    p_agent_id uuid
+)
+    RETURNS SETOF public.tasks
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_task_id uuid;
+    v_chain_id uuid;
+    v_owned_chain_id uuid;
+BEGIN
+    -- Check if agent already owns a chain
+    SELECT c.id INTO v_owned_chain_id
+    FROM public.chains c
+    WHERE c.owner_agent_id = p_agent_id
+    LIMIT 1;
+
+    -- Case 1: Agent already owns a chain - can only claim tasks from that chain
+    IF v_owned_chain_id IS NOT NULL THEN
+        SELECT t.id, t.chain_id
+        INTO v_task_id, v_chain_id
+        FROM public.tasks t
+        WHERE t.channel_id = p_channel_id
+          AND t.chain_id = v_owned_chain_id
+          AND t.status = 'queued'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.tasks
+            WHERE chain_id = t.chain_id
+              AND status = 'locked'
+        )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.tasks
+            WHERE chain_id = t.chain_id
+              AND sequence < t.sequence
+              AND status != 'done'
+        )
+        ORDER BY t.sequence ASC
+            FOR UPDATE SKIP LOCKED
+        LIMIT 1;
+
+        IF v_task_id IS NOT NULL THEN
+            RETURN QUERY
+                UPDATE public.tasks
+                    SET status = 'in_progress',
+                        assigned_agent_id = p_agent_id,
+                        claimed_at = NOW(),
+                        updated_at = NOW()
+                    WHERE id = v_task_id
+                    RETURNING *;
+
+            RETURN;
+        END IF;
+
+        -- Agent owns another chain but cannot claim from any other chain.
+        RETURN;
+    END IF;
+
+    -- Case 2: Agent doesn't own a chain - claim next eligible task from unowned/unlocked chain
+    SELECT t.id, t.chain_id
+    INTO v_task_id, v_chain_id
+    FROM public.tasks t
+             JOIN public.chains c ON t.chain_id = c.id
+    WHERE t.channel_id = p_channel_id
+      AND t.status = 'queued'
+      AND c.status != 'locked'
+      AND c.owner_agent_id IS NULL  -- Chain must not be owned by anyone
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.tasks
+        WHERE chain_id = t.chain_id
+          AND status = 'locked'
+    )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.tasks
+        WHERE chain_id = t.chain_id
+          AND sequence < t.sequence
+          AND status != 'done'
+    )
+    ORDER BY c.created_at ASC, t.sequence ASC
+        FOR UPDATE SKIP LOCKED
+    LIMIT 1;
+
+    IF v_task_id IS NOT NULL THEN
+        -- Set chain ownership and status
+        UPDATE public.chains
+        SET status = 'in_progress',
+            owner_agent_id = p_agent_id,
+            updated_at = NOW()
+        WHERE id = v_chain_id;
+
+        RETURN QUERY
+            UPDATE public.tasks
+                SET status = 'in_progress',
+                    assigned_agent_id = p_agent_id,
+                    claimed_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = v_task_id
+                RETURNING *;
+
+        RETURN;
+    END IF;
+
+    -- No task available
+    RETURN;
+END;
+$$;
+
+-- Step 4: Create helper function to update chain status (used manually, not auto-triggered)
+-- This function updates chain status based on task completion but does NOT release ownership
+-- Ownership must be released explicitly via detach API
+CREATE OR REPLACE FUNCTION public.update_chain_status(p_chain_id uuid)
+    RETURNS VOID
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_all_done boolean;
+    v_has_failed boolean;
+BEGIN
+    -- Check if all tasks are done or failed
+    SELECT NOT EXISTS (
+        SELECT 1
+        FROM public.tasks
+        WHERE chain_id = p_chain_id
+          AND status NOT IN ('done', 'failed')
+    ) INTO v_all_done;
+
+    -- Check if any task failed
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.tasks
+        WHERE chain_id = p_chain_id
+          AND status = 'failed'
+    ) INTO v_has_failed;
+
+    -- Update chain status ONLY (ownership remains with agent until explicit detach)
+    IF v_all_done THEN
+        UPDATE public.chains
+        SET status = CASE WHEN v_has_failed THEN 'failed' ELSE 'done' END,
+            updated_at = NOW()
+        WHERE id = p_chain_id;
+    END IF;
+END;
+$$;
+
+-- Step 5: Create manual detach function (called by API)
+CREATE OR REPLACE FUNCTION public.detach_chain_ownership(p_chain_id uuid, p_agent_id uuid)
+    RETURNS VOID
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE public.chains
+    SET owner_agent_id = NULL,
+        updated_at = NOW()
+    WHERE id = p_chain_id
+      AND owner_agent_id = p_agent_id; -- Only owner can detach
+END;
+$$;

--- a/supabase/migrations/0013_locked_status.sql
+++ b/supabase/migrations/0013_locked_status.sql
@@ -1,0 +1,29 @@
+-- Add 'locked' to task and chain status values.
+-- PostgreSQL text columns don't have enum constraints by default in this schema,
+-- so this migration is mainly documentation. If check constraints exist, update them:
+
+-- Update task status check constraint if it exists
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'tasks_status_check' AND table_name = 'tasks'
+  ) THEN
+    ALTER TABLE public.tasks DROP CONSTRAINT tasks_status_check;
+    ALTER TABLE public.tasks ADD CONSTRAINT tasks_status_check
+      CHECK (status IN ('queued', 'in_progress', 'done', 'failed', 'locked'));
+  END IF;
+END $$;
+
+-- Update chain status check constraint if it exists
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'chains_status_check' AND table_name = 'chains'
+  ) THEN
+    ALTER TABLE public.chains DROP CONSTRAINT chains_status_check;
+    ALTER TABLE public.chains ADD CONSTRAINT chains_status_check
+      CHECK (status IN ('queued', 'in_progress', 'done', 'failed', 'locked'));
+  END IF;
+END $$;

--- a/supabase/migrations/0014_agent_session_request_token.sql
+++ b/supabase/migrations/0014_agent_session_request_token.sql
@@ -1,0 +1,7 @@
+-- Add token used to correlate request_claude_session task completion events.
+alter table public.tasks
+add column if not exists agent_session_request_token text null;
+
+create unique index if not exists uq_tasks_agent_session_request_token
+on public.tasks (agent_session_request_token)
+where agent_session_request_token is not null;

--- a/supabase/migrations/0015_fix_claim_task_owner_persistence.sql
+++ b/supabase/migrations/0015_fix_claim_task_owner_persistence.sql
@@ -1,0 +1,109 @@
+-- 0015_fix_claim_task_owner_persistence.sql
+-- Keep chain ownership until explicit detach (or lease expiry policy),
+-- and ensure only owner can claim newly added tasks in owned chains.
+
+DROP FUNCTION IF EXISTS public.claim_task(uuid, uuid);
+
+CREATE OR REPLACE FUNCTION public.claim_task(
+    p_channel_id uuid,
+    p_agent_id uuid
+)
+    RETURNS SETOF public.tasks
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_task_id uuid;
+    v_chain_id uuid;
+    v_owned_chain_id uuid;
+BEGIN
+    -- Ownership persists regardless of chain status.
+    SELECT c.id INTO v_owned_chain_id
+    FROM public.chains c
+    WHERE c.owner_agent_id = p_agent_id
+    LIMIT 1;
+
+    -- Owner can only claim from the owned chain.
+    IF v_owned_chain_id IS NOT NULL THEN
+        SELECT t.id, t.chain_id
+        INTO v_task_id, v_chain_id
+        FROM public.tasks t
+        WHERE t.channel_id = p_channel_id
+          AND t.chain_id = v_owned_chain_id
+          AND t.status = 'queued'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.tasks
+            WHERE chain_id = t.chain_id
+              AND status = 'locked'
+        )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.tasks
+            WHERE chain_id = t.chain_id
+              AND sequence < t.sequence
+              AND status != 'done'
+        )
+        ORDER BY t.sequence ASC
+            FOR UPDATE SKIP LOCKED
+        LIMIT 1;
+
+        IF v_task_id IS NOT NULL THEN
+            RETURN QUERY
+                UPDATE public.tasks
+                    SET status = 'in_progress',
+                        assigned_agent_id = p_agent_id,
+                        claimed_at = NOW(),
+                        updated_at = NOW()
+                    WHERE id = v_task_id
+                    RETURNING *;
+        END IF;
+
+        RETURN;
+    END IF;
+
+    -- Unowned agents can claim from unowned/unlocked chains only.
+    SELECT t.id, t.chain_id
+    INTO v_task_id, v_chain_id
+    FROM public.tasks t
+             JOIN public.chains c ON t.chain_id = c.id
+    WHERE t.channel_id = p_channel_id
+      AND t.status = 'queued'
+      AND c.status != 'locked'
+      AND c.owner_agent_id IS NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.tasks
+        WHERE chain_id = t.chain_id
+          AND status = 'locked'
+    )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.tasks
+        WHERE chain_id = t.chain_id
+          AND sequence < t.sequence
+          AND status != 'done'
+    )
+    ORDER BY c.created_at ASC, t.sequence ASC
+        FOR UPDATE SKIP LOCKED
+    LIMIT 1;
+
+    IF v_task_id IS NOT NULL THEN
+        UPDATE public.chains
+        SET status = 'in_progress',
+            owner_agent_id = p_agent_id,
+            updated_at = NOW()
+        WHERE id = v_chain_id;
+
+        RETURN QUERY
+            UPDATE public.tasks
+                SET status = 'in_progress',
+                    assigned_agent_id = p_agent_id,
+                    claimed_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = v_task_id
+                RETURNING *;
+    END IF;
+
+    RETURN;
+END;
+$$;

--- a/supabase/migrations/0016_relax_chain_claim_gate_for_failed_predecessors.sql
+++ b/supabase/migrations/0016_relax_chain_claim_gate_for_failed_predecessors.sql
@@ -1,0 +1,108 @@
+-- 0016_relax_chain_claim_gate_for_failed_predecessors.sql
+-- Allow claiming a later task when predecessors are terminal (done/failed).
+
+DROP FUNCTION IF EXISTS public.claim_task(uuid, uuid);
+
+CREATE OR REPLACE FUNCTION public.claim_task(
+    p_channel_id uuid,
+    p_agent_id uuid
+)
+    RETURNS SETOF public.tasks
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_task_id uuid;
+    v_chain_id uuid;
+    v_owned_chain_id uuid;
+BEGIN
+    -- Ownership persists regardless of chain status.
+    SELECT c.id INTO v_owned_chain_id
+    FROM public.chains c
+    WHERE c.owner_agent_id = p_agent_id
+    LIMIT 1;
+
+    -- Owner can only claim from the owned chain.
+    IF v_owned_chain_id IS NOT NULL THEN
+        SELECT t.id, t.chain_id
+        INTO v_task_id, v_chain_id
+        FROM public.tasks t
+        WHERE t.channel_id = p_channel_id
+          AND t.chain_id = v_owned_chain_id
+          AND t.status = 'queued'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.tasks
+            WHERE chain_id = t.chain_id
+              AND status = 'locked'
+        )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.tasks
+            WHERE chain_id = t.chain_id
+              AND sequence < t.sequence
+              AND status IN ('queued', 'in_progress')
+        )
+        ORDER BY t.sequence ASC
+            FOR UPDATE SKIP LOCKED
+        LIMIT 1;
+
+        IF v_task_id IS NOT NULL THEN
+            RETURN QUERY
+                UPDATE public.tasks
+                    SET status = 'in_progress',
+                        assigned_agent_id = p_agent_id,
+                        claimed_at = NOW(),
+                        updated_at = NOW()
+                    WHERE id = v_task_id
+                    RETURNING *;
+        END IF;
+
+        RETURN;
+    END IF;
+
+    -- Unowned agents can claim from unowned/unlocked chains only.
+    SELECT t.id, t.chain_id
+    INTO v_task_id, v_chain_id
+    FROM public.tasks t
+             JOIN public.chains c ON t.chain_id = c.id
+    WHERE t.channel_id = p_channel_id
+      AND t.status = 'queued'
+      AND c.status != 'locked'
+      AND c.owner_agent_id IS NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.tasks
+        WHERE chain_id = t.chain_id
+          AND status = 'locked'
+    )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.tasks
+        WHERE chain_id = t.chain_id
+          AND sequence < t.sequence
+          AND status IN ('queued', 'in_progress')
+    )
+    ORDER BY c.created_at ASC, t.sequence ASC
+        FOR UPDATE SKIP LOCKED
+    LIMIT 1;
+
+    IF v_task_id IS NOT NULL THEN
+        UPDATE public.chains
+        SET status = 'in_progress',
+            owner_agent_id = p_agent_id,
+            updated_at = NOW()
+        WHERE id = v_chain_id;
+
+        RETURN QUERY
+            UPDATE public.tasks
+                SET status = 'in_progress',
+                    assigned_agent_id = p_agent_id,
+                    claimed_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = v_task_id
+                RETURNING *;
+    END IF;
+
+    RETURN;
+END;
+$$;

--- a/tasks/0061-fix-queued-popover-refresh-focus-race.md
+++ b/tasks/0061-fix-queued-popover-refresh-focus-race.md
@@ -1,0 +1,16 @@
+# UI: Queued/Chain popover 입력 중 refresh 리렌더 경합 수정
+
+## 요구사항
+- REQUIREMENTS.md 참조: 4.3 작업 태스크 보드
+- 체인 생성 popover와 Queued task 생성 popover 입력 중 auto refresh(SSE/poll)로 인한 리렌더로 포커스/입력 draft가 끊기지 않아야 한다.
+
+## 작업 목록
+- [x] 현재 refresh/rerender 흐름 분석 및 원인 식별
+- [x] popover 입력 중에는 백그라운드 refresh에서 task board 리렌더를 건너뛰도록 수정
+- [x] 체인/queued popover 생성 완료 경로는 강제 리렌더로 즉시 반영되도록 분기 추가
+- [ ] 변경 동작 수동 검증
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `tasks/0061-fix-queued-popover-refresh-focus-race.md`
+- `coordinator/internal/httpapi/ui/app.js`

--- a/tasks/0062-fix-agent-list-order-jitter.md
+++ b/tasks/0062-fix-agent-list-order-jitter.md
@@ -1,0 +1,21 @@
+# 에이전트 대시보드 목록 순서 흔들림(리렌더링) 수정
+
+## 요구사항
+- REQUIREMENTS.md 참조: 4.2 웹뷰 대시보드
+- 에이전트 목록 응답은 이름 오름차순으로 고정해 리렌더링 시 순서가 바뀌지 않아야 한다.
+
+## 작업 목록
+- [x] `ListAgents` 정렬 기준(메모리/포스트그레스) 점검
+- [x] 메모리 스토어의 에이전트 목록 정렬을 이름 오름차순으로 수정
+- [x] 포스트그레스 스토어의 에이전트 목록 쿼리를 이름 오름차순으로 수정
+- [x] 정렬 회귀 테스트 추가
+- [x] 체크리스트 완료 처리
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `tasks/0062-fix-agent-list-order-jitter.md`
+- `tasks/INDEX.md`
+- `coordinator/internal/store/memory/memory.go`
+- `coordinator/internal/store/postgres/postgres.go`
+- `coordinator/internal/store/memory/memory_test.go`
+- `coordinator/internal/store/postgres/postgres_test.go`

--- a/tasks/0063-offline-worker-forces-claude-not-running.md
+++ b/tasks/0063-offline-worker-forces-claude-not-running.md
@@ -1,0 +1,21 @@
+# Worker Offline 시 Claude Not Running 강제
+
+## 요구사항
+- REQUIREMENTS.md 참조: 4.2 웹뷰 대시보드
+- Agent의 worker 상태가 `offline`이면 Claude Code 상태는 반드시 `not running`으로 표시되어야 한다.
+
+## 작업 목록
+- [x] `REQUIREMENTS.md`에 상태 연동 규칙 추가
+- [x] API 응답(`GET /v1/agents`, `GET /v1/dashboard`)에서 worker offline 시 `claude_status`를 `idle`로 정규화
+- [x] UI 렌더링에서 worker offline 시 Claude 상태를 `not running`으로 강제하는 안전장치 추가
+- [x] 상태 연동 회귀 테스트 추가
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `tasks/0063-offline-worker-forces-claude-not-running.md`
+- `tasks/INDEX.md`
+- `coordinator/internal/httpapi/agent_status.go`
+- `coordinator/internal/httpapi/agent_status_test.go`
+- `coordinator/internal/httpapi/handlers.go`
+- `coordinator/internal/httpapi/dashboard.go`
+- `coordinator/internal/httpapi/ui/app.js`

--- a/tasks/INDEX.md
+++ b/tasks/INDEX.md
@@ -24,5 +24,7 @@
 - `0020-acceptance-test-runbook.md` — **Done** — 로컬 실행/화면 확인/인수테스트 절차 문서화
 - `0021-interactive-prompts.md` — **Done** — 인터랙티브 선택지 감지 → 대시보드 표시 → 사용자 선택/주입
 - `0022-interactive-prompt-navigation.md` — **Done** — Enter/Tab/Arrow/Esc 기반 선택지 UI 감지 + 키 주입(옵션 선택)
+- `0049-request-session-token-completion.md` — **Done** — request_claude_session 완료를 전용 이벤트 + agent_session_request_token 기반으로 분리 처리
+- `0050-session-request-completion-hardening.md` — **Done** — 전용 완료 이벤트 payload 정규화 + task 상태 전이 실패 명시 에러 처리
 - `0054-enforce-chain-assign-subscription-check.md` — **Done** — 체인 수동 할당 시 채널 구독 검증 + UI 구독 추가 확인/재시도
 - `0055-fix-subscription-dropdown-edit-refresh-race.md` — **Done** — Agent subscription 드롭다운 편집 중 auto refresh 리렌더 경합 수정

--- a/tasks/INDEX.md
+++ b/tasks/INDEX.md
@@ -28,3 +28,6 @@
 - `0050-session-request-completion-hardening.md` — **Done** — 전용 완료 이벤트 payload 정규화 + task 상태 전이 실패 명시 에러 처리
 - `0054-enforce-chain-assign-subscription-check.md` — **Done** — 체인 수동 할당 시 채널 구독 검증 + UI 구독 추가 확인/재시도
 - `0055-fix-subscription-dropdown-edit-refresh-race.md` — **Done** — Agent subscription 드롭다운 편집 중 auto refresh 리렌더 경합 수정
+- `0061-fix-queued-popover-refresh-focus-race.md` — **Done** — 체인/Queued popover 입력 중 refresh 리렌더로 인한 포커스/드래프트 유실 방지
+- `0062-fix-agent-list-order-jitter.md` — **Done** — 에이전트 목록 응답을 이름 오름차순으로 고정해 대시보드 리렌더링 순서 흔들림 제거
+- `0063-offline-worker-forces-claude-not-running.md` — **Done** — Worker가 offline일 때 Claude 상태를 not running으로 강제


### PR DESCRIPTION
## Summary

- **DB: locked status 추가** (`0013_locked_status.sql`) - task/chain에 `locked` 상태값 추가
- **DB: agent_session_request_token 컬럼 추가** (`0014_agent_session_request_token.sql`) - claude session request task 완료 이벤트 매칭용 토큰 컬럼
- **deploy: 배포 스크립트 개선** - `.env.prod` 로드 순서 수정, 실행 권한 부여
- **feat: 에이전트 목록 이름순 정렬** - Memory/Postgres store 모두 `ListAgents`를 이름 오름차순으로 정렬하여 대시보드 리렌더링 시 순서 흔들림 제거
- **fix: Worker offline 시 Claude 상태 `not running` 강제** - API 응답에서 worker offline일 때 `claude_status=idle`로 정규화, UI에서는 `not running` 표시
- **fix: popover 입력 중 refresh 리렌더 방지** - 체인/Queued popover 입력 중 auto refresh로 인한 포커스/draft 유실 방지 (`shouldSkipTaskBoardRender`)

Closes #38