### PR TITLE
feat: add logging on clw-agent hook flow and follow-up fixes

### DIFF
--- a/Claude-Code-Remote/setup.js
+++ b/Claude-Code-Remote/setup.js
@@ -10,20 +10,47 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const readline = require('readline');
+const { execSync } = require('child_process');
 const dotenv = require('dotenv');
 
 const projectRoot = __dirname;
 const envPath = path.join(projectRoot, '.env');
 const legacyHookScriptPath = path.join(projectRoot, 'claude-hook-notify.js');
-const agentHookScriptPath = path.resolve(projectRoot, '..', 'agent', 'clw-agent.js');
+function resolveAgentScriptPath() {
+    const scriptName = 'clw-agent.js';
+    const pkgName = '@clwclw-monitor/agent';
+
+    // 1. 로컬 node_modules에서 찾기 (npm install로 로컬 설치한 경우)
+    try {
+        const pkgJson = require.resolve(pkgName + '/package.json');
+        const candidate = path.join(path.dirname(pkgJson), scriptName);
+        if (fs.existsSync(candidate)) return candidate;
+    } catch {}
+
+    // 2. 글로벌 node_modules에서 찾기 (npm install -g 한 경우)
+    //    npm root -g: homebrew, nvm, volta, fnm 등 어떤 방식이든 올바른 경로 반환
+    try {
+        const globalRoot = execSync('npm root -g', { encoding: 'utf8' }).trim();
+        const candidate = path.join(globalRoot, pkgName, scriptName);
+        if (fs.existsSync(candidate)) return candidate;
+    } catch {}
+
+    // 3. 모노레포: 상대경로
+    const monorepo = path.resolve(projectRoot, '..', 'agent', scriptName);
+    if (fs.existsSync(monorepo)) return monorepo;
+
+    // 4. 못 찾음 → null (legacy fallback)
+    return null;
+}
+const agentHookScriptPath = resolveAgentScriptPath();
 const defaultSessionMap = path.join(projectRoot, 'src', 'data', 'session-map.json');
 const i18nPath = path.join(projectRoot, 'setup-i18n.json');
 
 function resolveHookMode() {
     const raw = (process.env.CLAUDE_REMOTE_HOOK_TARGET || '').trim().toLowerCase();
     if (raw === 'legacy') return 'legacy';
-    if (raw === 'agent') return fs.existsSync(agentHookScriptPath) ? 'agent' : 'legacy';
-    return fs.existsSync(agentHookScriptPath) ? 'agent' : 'legacy';
+    if (raw === 'agent') return agentHookScriptPath ? 'agent' : 'legacy';
+    return agentHookScriptPath ? 'agent' : 'legacy';
 }
 
 const hookMode = resolveHookMode(); // 'agent' | 'legacy'

--- a/agent/clw-agent.js
+++ b/agent/clw-agent.js
@@ -78,7 +78,7 @@ function loadDotEnvIfPresent(filePath) {
 
 /** Per-process deploy mode. Set at startup by login/work command. */
 let _deployMode = null; // 'local' | 'prod' | null
-let _currentAgentId = (process.env.AGENT_ID || '').trim();
+let _currentAgentId = '';
 
 function getDeployMode() {
   if (_deployMode) return _deployMode;
@@ -93,6 +93,84 @@ function setDeployMode(mode) {
     throw new Error(`Invalid deploy mode: ${mode} (must be 'local' or 'prod')`);
   }
   _deployMode = mode;
+}
+
+const LOG_LEVEL_PRIORITY = Object.freeze({
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+});
+
+function normalizeLogLevel(level) {
+  const raw = String(level || '').trim().toLowerCase();
+  if (raw === 'debug' || raw === 'info' || raw === 'warn' || raw === 'error') {
+    return raw;
+  }
+  return 'info';
+}
+
+function currentLogLevel() {
+  return normalizeLogLevel(process.env.AGENT_LOG_LEVEL || 'info');
+}
+
+function shouldLog(level) {
+  const target = LOG_LEVEL_PRIORITY[normalizeLogLevel(level)];
+  const current = LOG_LEVEL_PRIORITY[currentLogLevel()];
+  return target >= current;
+}
+
+function logAt(level, ...args) {
+  if (!shouldLog(level)) return;
+  const normalized = normalizeLogLevel(level);
+  if (normalized === 'error') {
+    console.error(...args);
+    return;
+  }
+  if (normalized === 'warn') {
+    console.warn(...args);
+    return;
+  }
+  console.log(...args);
+}
+
+function logDebug(...args) {
+  logAt('debug', ...args);
+}
+
+function logInfo(...args) {
+  logAt('info', ...args);
+}
+
+function logWarn(...args) {
+  logAt('warn', ...args);
+}
+
+function logError(...args) {
+  logAt('error', ...args);
+}
+
+function compactLogValue(value) {
+  if (value === undefined || value === null) return '';
+  const s = String(value).replace(/\s+/g, ' ').trim();
+  if (!s) return '';
+  if (s.length <= 120) return s;
+  return s.slice(0, 117) + '...';
+}
+
+function logHookFlow(stage, fields = {}) {
+  const normalizedStage = compactLogValue(stage);
+  const parts = [];
+  if (fields && typeof fields === 'object') {
+    for (const [k, v] of Object.entries(fields)) {
+      const key = compactLogValue(k);
+      const value = compactLogValue(v);
+      if (!key || !value) continue;
+      parts.push(`${key}=${value}`);
+    }
+  }
+  const suffix = parts.length > 0 ? ` ${parts.join(' ')}` : '';
+  logDebug(`[agent][hook-flow] ${normalizedStage}${suffix}`);
 }
 
 function usage() {
@@ -115,11 +193,11 @@ function usage() {
 Env:
   COORDINATOR_URL          default: http://localhost:8080 (also persisted per mode)
   COORDINATOR_AUTH_TOKEN   optional
-  AGENT_ID                 optional process-level override (otherwise issued by heartbeat)
   AGENT_NAME               optional (default: hostname)
   AGENT_MODE               optional: "local" or "prod" (set during login, persisted)
   AGENT_CHANNELS           optional (comma-separated subscriptions; e.g. "backend-domain,notify")
   AGENT_STATE_DIR          optional (state dir override; for multi-agent/multi-session)
+  AGENT_LOG_LEVEL          optional: debug|info|warn|error (default: info)
   AGENT_HEARTBEAT_INTERVAL_SEC  default: 15
   AGENT_WORK_POLL_INTERVAL_SEC  default: 5
 `);
@@ -536,10 +614,29 @@ function ensureHookDeliveryQueued(record) {
   const deliveryId = String(record.delivery_id).trim();
   if (!deliveryId) return null;
 
-  if (isHookDeliveryFinalized(deliveryId) || queueHasPendingDelivery(deliveryId)) {
+  if (isHookDeliveryFinalized(deliveryId)) {
+    logHookFlow('queue.skip_finalized', {
+      delivery_id: deliveryId,
+      pane_id: record.pane_id,
+      hook_type: record.hook_type,
+    });
+    return record;
+  }
+  if (queueHasPendingDelivery(deliveryId)) {
+    logHookFlow('queue.skip_duplicate_pending', {
+      delivery_id: deliveryId,
+      pane_id: record.pane_id,
+      hook_type: record.hook_type,
+    });
     return record;
   }
   appendJsonl(hookQueuePendingPath(), record);
+  logHookFlow('queue.enqueued', {
+    delivery_id: deliveryId,
+    pane_id: record.pane_id,
+    hook_type: record.hook_type,
+    source: record.source,
+  });
   return record;
 }
 
@@ -552,7 +649,14 @@ function enqueueHookDelivery(hookType, paneId, cwd, opts = {}) {
 function appendHookDeliveryAck(deliveryId, paneId, source = 'unknown', extra = {}) {
   const id = String(deliveryId || '').trim();
   if (!id) return false;
-  if (isHookDeliveryFinalized(id)) return false;
+  if (isHookDeliveryFinalized(id)) {
+    logHookFlow('queue.ack_skip_finalized', {
+      delivery_id: id,
+      pane_id: paneId,
+      source,
+    });
+    return false;
+  }
 
   appendJsonl(hookQueueAckPath(), {
     version: HOOK_QUEUE_SCHEMA_VERSION,
@@ -562,13 +666,25 @@ function appendHookDeliveryAck(deliveryId, paneId, source = 'unknown', extra = {
     ts: new Date().toISOString(),
     ...extra,
   });
+  logHookFlow('queue.ack_appended', {
+    delivery_id: id,
+    pane_id: paneId,
+    source,
+  });
   return true;
 }
 
 function appendHookDeliveryDeadletter(deliveryId, paneId, reason, attempts = 0, extra = {}) {
   const id = String(deliveryId || '').trim();
   if (!id) return false;
-  if (isHookDeliveryFinalized(id)) return false;
+  if (isHookDeliveryFinalized(id)) {
+    logHookFlow('queue.deadletter_skip_finalized', {
+      delivery_id: id,
+      pane_id: paneId,
+      reason,
+    });
+    return false;
+  }
 
   appendJsonl(hookQueueDeadletterPath(), {
     version: HOOK_QUEUE_SCHEMA_VERSION,
@@ -578,6 +694,12 @@ function appendHookDeliveryDeadletter(deliveryId, paneId, reason, attempts = 0, 
     reason: String(reason || 'unknown').trim() || 'unknown',
     ts: new Date().toISOString(),
     ...extra,
+  });
+  logHookFlow('queue.deadletter_appended', {
+    delivery_id: id,
+    pane_id: paneId,
+    reason,
+    attempts: Number(attempts || 0),
   });
   return true;
 }
@@ -609,9 +731,17 @@ function listPendingHookDeliveries(opts = {}) {
     });
   }
 
-  return Array.from(dedup.values())
+  const list = Array.from(dedup.values())
     .sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at))
     .slice(0, limit);
+  if (list.length > 0) {
+    logHookFlow('queue.pending_loaded', {
+      pane_id: paneId || 'all',
+      count: list.length,
+      limit,
+    });
+  }
+  return list;
 }
 
 function configureStateDirForWork(paneIdOrTarget) {
@@ -826,19 +956,49 @@ function runLegacyHook(type) {
   return result.status ?? 1;
 }
 
-async function fetchCurrentTaskFromCoordinator() {
+async function fetchCurrentTaskFromCoordinator(context = '') {
+  const traceContext = String(context || '').trim() || 'unspecified';
   try {
     const agentId = getCurrentAgentId();
-    if (!agentId) return null;
-    const result = await getJson(`/v1/agents/${agentId}/current-task`);
+    if (!agentId) {
+      logDebug(`[agent][current-task] request skipped: ${JSON.stringify({
+        context: traceContext,
+        reason: 'missing_agent_id',
+      })}`);
+      return null;
+    }
+    const path = `/v1/agents/${agentId}/current-task`;
+    logDebug(`[agent][current-task] request: ${JSON.stringify({
+      context: traceContext,
+      method: 'GET',
+      path,
+      body: {},
+    })}`);
+    const result = await getJson(path);
+    logDebug(`[agent][current-task] response: ${JSON.stringify({
+      context: traceContext,
+      status_code: 200,
+      body: result || {},
+    })}`);
     return result?.task || null;
   } catch (err) {
     const errMsg = String(err?.message || err);
 
     // 404 means no current task (expected case)
     if (errMsg.includes('404')) {
+      logDebug(`[agent][current-task] response: ${JSON.stringify({
+        context: traceContext,
+        status_code: 404,
+        body: errMsg,
+      })}`);
       return null;
     }
+
+    logDebug(`[agent][current-task] response: ${JSON.stringify({
+      context: traceContext,
+      status_code: 'error',
+      body: errMsg,
+    })}`);
 
     // ECONNREFUSED = Coordinator not running
     if (errMsg.includes('ECONNREFUSED') || errMsg.includes('connect')) {
@@ -969,7 +1129,14 @@ function startAgentd() {
       const paneId = String(msg?.paneId || msg?.pane_id || '').trim();
       const hookType = sanitizeHookType(msg?.hookType || msg?.hook_type || '');
       const cwd = String(msg?.cwd || '').trim() || process.cwd();
-      if (!paneId || !hookType) return null;
+      if (!paneId || !hookType) {
+        logHookFlow('agentd.parse_invalid', {
+          pane_id: paneId || 'none',
+          hook_type: hookType || 'none',
+          source,
+        });
+        return null;
+      }
 
       return buildHookDeliveryRecord(hookType, paneId, cwd, {
         deliveryId: msg?.deliveryId || msg?.delivery_id,
@@ -986,6 +1153,11 @@ function startAgentd() {
 
       const backlog = listPendingHookDeliveries({ paneId: normalizedPane, limit: HOOK_REPLAY_BATCH });
       if (backlog.length === 0) return;
+      logHookFlow('agentd.replay.begin', {
+        pane_id: normalizedPane,
+        reason: reason || 'unknown',
+        count: backlog.length,
+      });
 
       for (const delivery of backlog) {
         const deliveryId = String(delivery.delivery_id || '').trim();
@@ -1005,6 +1177,12 @@ function startAgentd() {
           createdAt: delivery.created_at,
           replay: true,
           replayReason: reason,
+        });
+        logHookFlow('agentd.replay.enqueue_forward', {
+          request_id: requestId,
+          delivery_id: deliveryId,
+          pane_id: normalizedPane,
+          reason: reason || 'unknown',
         });
         forwardHookToWorker(requestId);
       }
@@ -1044,6 +1222,12 @@ function startAgentd() {
 
     function handleHookRequest(msg, hookSocket) {
       const requestId = msg.id;
+      logHookFlow('agentd.hook_request.received', {
+        request_id: requestId,
+        pane_id: msg?.paneId || msg?.pane_id || '',
+        hook_type: msg?.hookType || msg?.hook_type || '',
+        delivery_id: msg?.deliveryId || msg?.delivery_id || '',
+      });
       const delivery = parseHookDelivery(msg, 'hook');
       if (!delivery) {
         notifyHookSocket(hookSocket, {
@@ -1057,6 +1241,11 @@ function startAgentd() {
 
       ensureHookDeliveryQueued(delivery);
       if (isHookDeliveryFinalized(delivery.delivery_id)) {
+        logHookFlow('agentd.hook_request.deduped_finalized', {
+          request_id: requestId,
+          delivery_id: delivery.delivery_id,
+          pane_id: delivery.pane_id,
+        });
         notifyHookSocket(hookSocket, {
           type: 'hook_result',
           requestId,
@@ -1070,6 +1259,11 @@ function startAgentd() {
       const worker = workers.get(delivery.pane_id);
       if (!worker) {
         console.log(`[agentd] no worker for pane=${delivery.pane_id}, keeping queued delivery=${delivery.delivery_id}`);
+        logHookFlow('agentd.hook_request.queued_no_worker', {
+          request_id: requestId,
+          delivery_id: delivery.delivery_id,
+          pane_id: delivery.pane_id,
+        });
         notifyHookSocket(hookSocket, {
           type: 'hook_result',
           requestId,
@@ -1081,6 +1275,11 @@ function startAgentd() {
       }
 
       if (inFlightDeliveryIDs.has(delivery.delivery_id)) {
+        logHookFlow('agentd.hook_request.in_flight', {
+          request_id: requestId,
+          delivery_id: delivery.delivery_id,
+          pane_id: delivery.pane_id,
+        });
         notifyHookSocket(hookSocket, {
           type: 'hook_result',
           requestId,
@@ -1102,6 +1301,11 @@ function startAgentd() {
         deliveryId: delivery.delivery_id,
         createdAt: delivery.created_at,
       });
+      logHookFlow('agentd.hook_request.forward_ready', {
+        request_id: requestId,
+        delivery_id: delivery.delivery_id,
+        pane_id: delivery.pane_id,
+      });
 
       forwardHookToWorker(requestId);
     }
@@ -1109,6 +1313,9 @@ function startAgentd() {
     function handleReplayRequest(msg, socket) {
       const paneId = String(msg?.paneId || msg?.pane_id || socketToPaneId.get(socket) || '').trim();
       if (!paneId) return;
+      logHookFlow('agentd.replay.requested', {
+        pane_id: paneId,
+      });
       flushPendingQueueForPane(paneId, 'replay_request');
     }
 
@@ -1141,6 +1348,13 @@ function startAgentd() {
         deliveryId: pending.deliveryId,
         createdAt: pending.createdAt,
       });
+      logHookFlow('agentd.forward.sent', {
+        request_id: requestId,
+        delivery_id: pending.deliveryId,
+        pane_id: pending.paneId,
+        hook_type: pending.hookType,
+        attempt: pending.attempts,
+      });
 
       // Set ack timeout
       pending.timer = setTimeout(() => {
@@ -1149,6 +1363,12 @@ function startAgentd() {
 
         if (p.attempts < HOOK_MAX_RETRIES) {
           console.log(`[agentd] hook_ack timeout, retrying (attempt ${p.attempts + 1}/${HOOK_MAX_RETRIES})`);
+          logHookFlow('agentd.forward.timeout_retry', {
+            request_id: requestId,
+            delivery_id: p.deliveryId,
+            pane_id: p.paneId,
+            attempt: p.attempts,
+          });
           forwardHookToWorker(requestId);
         } else {
           const dead = appendHookDeliveryDeadletter(
@@ -1166,6 +1386,12 @@ function startAgentd() {
             error: 'ack timeout',
             deliveryId: p.deliveryId,
           });
+          logHookFlow('agentd.forward.timeout_deadletter', {
+            request_id: requestId,
+            delivery_id: p.deliveryId,
+            pane_id: p.paneId,
+            attempts: p.attempts,
+          });
           releasePendingHook(requestId);
         }
       }, HOOK_ACK_TIMEOUT);
@@ -1174,6 +1400,13 @@ function startAgentd() {
     function handleHookAck(msg) {
       const { requestId, success, taskId, error } = msg;
       const phase = String(msg?.phase || '').trim() || 'delivery';
+      logHookFlow('agentd.hook_ack.received', {
+        request_id: requestId,
+        phase,
+        success: success === true ? 'true' : 'false',
+        delivery_id: msg?.deliveryId || msg?.delivery_id || '',
+        task_id: taskId || '',
+      });
       const pending = pendingHooks.get(requestId);
       if (!pending) {
         if (phase === 'business') {
@@ -1187,6 +1420,12 @@ function startAgentd() {
 
       if (phase === 'business') {
         console.log(`[agentd] hook business_result: delivery=${pending.deliveryId} success=${success === true} task=${taskId || ''}`);
+        logHookFlow('agentd.hook_ack.business', {
+          request_id: requestId,
+          delivery_id: pending.deliveryId,
+          success: success === true ? 'true' : 'false',
+          task_id: taskId || '',
+        });
         return;
       }
 
@@ -1202,6 +1441,11 @@ function startAgentd() {
           success: true,
           taskId,
           deliveryId: pending.deliveryId,
+        });
+        logHookFlow('agentd.hook_ack.delivery_ok', {
+          request_id: requestId,
+          delivery_id: pending.deliveryId,
+          pane_id: pending.paneId,
         });
         releasePendingHook(requestId);
         console.log(`[agentd] hook_ack delivery: request=${requestId} delivery=${pending.deliveryId}`);
@@ -1227,6 +1471,13 @@ function startAgentd() {
         success: false,
         error: error || 'delivery ack failed',
         deliveryId: pending.deliveryId,
+      });
+      logHookFlow('agentd.hook_ack.delivery_failed', {
+        request_id: requestId,
+        delivery_id: pending.deliveryId,
+        pane_id: pending.paneId,
+        attempts: pending.attempts,
+        error: error || 'delivery ack failed',
       });
       releasePendingHook(requestId);
       console.log(`[agentd] hook_ack delivery failed: request=${requestId} delivery=${pending.deliveryId}`);
@@ -1322,10 +1573,23 @@ function tryHookViaAgentd(input, hookTypeFallback = '') {
     ? String(input?.cwd || '').trim() || process.cwd()
     : process.cwd();
 
-  if (!paneId || !hookType) return Promise.resolve(false);
+  if (!paneId || !hookType) {
+    logHookFlow('hook.ipc.skip_invalid', {
+      pane_id: paneId || 'none',
+      hook_type: hookType || 'none',
+    });
+    return Promise.resolve(false);
+  }
 
   const sockPath = resolveSocketPath();
-  if (!fs.existsSync(sockPath)) return Promise.resolve(false);
+  if (!fs.existsSync(sockPath)) {
+    logHookFlow('hook.ipc.socket_missing', {
+      pane_id: paneId,
+      hook_type: hookType,
+      socket: sockPath,
+    });
+    return Promise.resolve(false);
+  }
 
   return new Promise((resolve) => {
     const TOTAL_TIMEOUT = 90000;
@@ -1336,21 +1600,63 @@ function tryHookViaAgentd(input, hookTypeFallback = '') {
       settled = true;
       clearTimeout(timer);
       try { socket.end(); } catch {}
+      logHookFlow('hook.ipc.finish', {
+        pane_id: paneId,
+        hook_type: hookType,
+        delivery_id: deliveryId || 'none',
+        success: result ? 'true' : 'false',
+      });
       resolve(result);
     };
 
-    const timer = setTimeout(() => finish(false), TOTAL_TIMEOUT);
+    const timer = setTimeout(() => {
+      logHookFlow('hook.ipc.timeout', {
+        pane_id: paneId,
+        hook_type: hookType,
+        delivery_id: deliveryId || 'none',
+        timeout_ms: TOTAL_TIMEOUT,
+      });
+      finish(false);
+    }, TOTAL_TIMEOUT);
 
     const socket = net.createConnection(sockPath);
 
     socket.setEncoding('utf8');
-    socket.on('error', () => finish(false));
-    socket.on('close', () => finish(false));
+    socket.on('error', (err) => {
+      logHookFlow('hook.ipc.error', {
+        pane_id: paneId,
+        hook_type: hookType,
+        delivery_id: deliveryId || 'none',
+        error: String(err?.message || err),
+      });
+      finish(false);
+    });
+    socket.on('close', () => {
+      logHookFlow('hook.ipc.closed', {
+        pane_id: paneId,
+        hook_type: hookType,
+        delivery_id: deliveryId || 'none',
+      });
+      finish(false);
+    });
 
     const parser = createNdjsonParser((msg) => {
       if (msg.type === 'hook_result') {
+        logHookFlow('hook.ipc.hook_result', {
+          pane_id: paneId,
+          hook_type: hookType,
+          delivery_id: msg?.deliveryId || deliveryId || 'none',
+          request_id: msg?.requestId || 'none',
+          success: msg?.success === true ? 'true' : 'false',
+          queued: msg?.queued === true ? 'true' : 'false',
+        });
         finish(msg.success === true);
       } else if (msg.type === 'hook_no_match') {
+        logHookFlow('hook.ipc.no_match', {
+          pane_id: paneId,
+          hook_type: hookType,
+          request_id: msg?.requestId || 'none',
+        });
         finish(false);
       }
     });
@@ -1366,6 +1672,11 @@ function tryHookViaAgentd(input, hookTypeFallback = '') {
       };
       if (deliveryId) payload.deliveryId = deliveryId;
       if (createdAt) payload.createdAt = createdAt;
+      logHookFlow('hook.ipc.send_request', {
+        pane_id: paneId,
+        hook_type: hookType,
+        delivery_id: deliveryId || 'none',
+      });
       sendMsg(socket, payload);
     });
   });
@@ -1376,10 +1687,10 @@ function tryHookViaAgentd(input, hookTypeFallback = '') {
 // ═══════════════════════════════════════════════════════════════════════════
 
 async function hookDirectCoordinator(type, detectedPaneId, detectedTarget) {
-  process.stderr.write(`[agent] ═══ Coordinator Upload Starting ═══\n`);
-  process.stderr.write(`[agent] Hook type: ${type}\n`);
-  process.stderr.write(`[agent] Pane ID: ${detectedPaneId || 'N/A'}\n`);
-  process.stderr.write(`[agent] Coordinator URL: ${coordinatorBaseUrl()}\n`);
+  logDebug('[agent] ═══ Coordinator Upload Starting ═══');
+  logDebug(`[agent] Hook type: ${type}`);
+  logDebug(`[agent] Pane ID: ${detectedPaneId || 'N/A'}`);
+  logDebug(`[agent] Coordinator URL: ${coordinatorBaseUrl()}`);
 
   // Detect Claude Code running status
   let claudeRunning = false;
@@ -1414,7 +1725,7 @@ async function hookDirectCoordinator(type, detectedPaneId, detectedTarget) {
     console.log(`[agent] hook completed: agent_id=${agentId}, coordinator=${coordinatorBaseUrl()}`);
 
     console.log(`[agent] Fetching current task from coordinator...`);
-    const current = await fetchCurrentTaskFromCoordinator();
+    const current = await fetchCurrentTaskFromCoordinator('hook_direct.completed');
     console.log(`[agent] current task from coordinator: ${current ? JSON.stringify({ id: current.id, title: current.title, assigned_agent_id: current.assigned_agent_id }) : 'null'}`);
 
     if (current && current.id) {
@@ -1527,7 +1838,7 @@ function connectToAgentd(paneId, agentId, mode, coordinatorUrl, channels) {
         if (!resolved) {
           resolved = true;
           clearTimeout(timeout);
-          console.log(`[agent] registered with agentd: pane=${paneId}`);
+          logDebug(`[agent] registered with agentd: pane=${paneId}`);
           resolve(socket);
         }
       }
@@ -1541,6 +1852,7 @@ function requestHookReplayFromAgentd(agentdSocket, paneId) {
   if (!agentdSocket || agentdSocket.destroyed) return;
   const normalizedPane = String(paneId || '').trim();
   if (!normalizedPane) return;
+  logHookFlow('worker.replay_request.send', { pane_id: normalizedPane });
   sendMsg(agentdSocket, { type: 'replay_request', paneId: normalizedPane });
 }
 
@@ -1557,8 +1869,19 @@ function setupAgentdListener(agentdSocket, tmuxTarget, tmuxPaneId, channels) {
 async function handleHookForward(agentdSocket, msg, tmuxTarget, tmuxPaneId) {
   const { requestId, hookType, paneId, cwd } = msg;
   const deliveryId = String(msg?.deliveryId || msg?.delivery_id || '').trim();
+  logHookFlow('worker.hook_forward.received', {
+    request_id: requestId || 'none',
+    delivery_id: deliveryId || 'none',
+    pane_id: paneId || tmuxPaneId || 'none',
+    hook_type: hookType || 'none',
+  });
   if (agentdSocket && requestId) {
     // Delivery ACK: receiving worker accepted this message.
+    logHookFlow('worker.hook_forward.delivery_ack.send', {
+      request_id: requestId,
+      delivery_id: deliveryId || 'none',
+      pane_id: tmuxPaneId || paneId || 'none',
+    });
     sendMsg(agentdSocket, {
       type: 'hook_ack',
       requestId,
@@ -1595,10 +1918,21 @@ async function handleHookForward(agentdSocket, msg, tmuxTarget, tmuxPaneId) {
 
     let taskId = '';
     if (hookType === 'completed') {
-      const current = await fetchCurrentTaskFromCoordinator();
+      const current = await fetchCurrentTaskFromCoordinator('hook_forward.completed');
+      logHookFlow('worker.hook_forward.current_task', {
+        request_id: requestId || 'none',
+        delivery_id: deliveryId || 'none',
+        task_id: current?.id || 'none',
+      });
       if (current && current.id) {
         const result = await completeTask(current.id);
         taskId = current.id;
+        logHookFlow('worker.hook_forward.complete_attempt', {
+          request_id: requestId || 'none',
+          delivery_id: deliveryId || 'none',
+          task_id: current.id,
+          result: result ? 'ok' : 'null',
+        });
 
         await emitEvent('task.completed', {
           task_id: current.id,
@@ -1623,6 +1957,12 @@ async function handleHookForward(agentdSocket, msg, tmuxTarget, tmuxPaneId) {
     }
 
     if (agentdSocket && requestId) {
+      logHookFlow('worker.hook_forward.business_ack.send', {
+        request_id: requestId,
+        delivery_id: deliveryId || 'none',
+        task_id: taskId || 'none',
+        success: 'true',
+      });
       sendMsg(agentdSocket, {
         type: 'hook_ack',
         requestId,
@@ -1634,7 +1974,18 @@ async function handleHookForward(agentdSocket, msg, tmuxTarget, tmuxPaneId) {
     }
   } catch (err) {
     console.error(`[agent] hook_forward handling failed: ${err.message}`);
+    logHookFlow('worker.hook_forward.error', {
+      request_id: requestId || 'none',
+      delivery_id: deliveryId || 'none',
+      error: String(err?.message || err),
+    });
     if (agentdSocket && requestId) {
+      logHookFlow('worker.hook_forward.business_ack.send', {
+        request_id: requestId,
+        delivery_id: deliveryId || 'none',
+        task_id: 'none',
+        success: 'false',
+      });
       sendMsg(agentdSocket, {
         type: 'hook_ack',
         requestId,
@@ -1677,6 +2028,11 @@ async function pullHookQueueForPane(tmuxTarget, tmuxPaneId, maxItems = HOOK_QUEU
   if (!paneId) return 0;
 
   const pending = listPendingHookDeliveries({ paneId, limit: maxItems });
+  logHookFlow('worker.pull.scan', {
+    pane_id: paneId,
+    pending_count: pending.length,
+    max_items: maxItems,
+  });
   if (pending.length === 0) return 0;
 
   let processed = 0;
@@ -1687,6 +2043,12 @@ async function pullHookQueueForPane(tmuxTarget, tmuxPaneId, maxItems = HOOK_QUEU
     if (isHookDeliveryFinalized(deliveryId)) continue;
 
     rememberPulledDelivery(deliveryId);
+    logHookFlow('worker.pull.process', {
+      pane_id: paneId,
+      delivery_id: deliveryId,
+      hook_type: delivery.hook_type,
+      source: delivery.source || 'unknown',
+    });
     appendHookDeliveryAck(deliveryId, paneId, 'worker_pull_delivery', {
       source: delivery.source || 'hook',
     });
@@ -1701,9 +2063,18 @@ async function pullHookQueueForPane(tmuxTarget, tmuxPaneId, maxItems = HOOK_QUEU
       }, tmuxTarget, tmuxPaneId);
     } catch (err) {
       console.error(`[agent] queue pull delivery failed: id=${deliveryId} err=${String(err?.message || err)}`);
+      logHookFlow('worker.pull.error', {
+        pane_id: paneId,
+        delivery_id: deliveryId,
+        error: String(err?.message || err),
+      });
     }
     processed++;
   }
+  logHookFlow('worker.pull.done', {
+    pane_id: paneId,
+    processed,
+  });
   return processed;
 }
 
@@ -2233,6 +2604,8 @@ function tmuxInject(target, text, paneId = '') {
     throw new Error('tmux send-keys failed');
   }
   // Use C-Enter for Claude Code submission (Enter alone = newline)
+  // Send twice to ensure submission goes through
+  spawnSync('tmux', ['send-keys', '-t', resolved, 'C-Enter'], { stdio: 'ignore' });
   spawnSync('tmux', ['send-keys', '-t', resolved, 'C-Enter'], { stdio: 'ignore' });
 }
 
@@ -2263,6 +2636,8 @@ function tmuxSend(target, text, opts = {}) {
     }
   }
   if (enter) {
+    // Send twice to ensure submission goes through
+    spawnSync('tmux', ['send-keys', '-t', resolved, 'Enter'], { stdio: 'ignore' });
     spawnSync('tmux', ['send-keys', '-t', resolved, 'Enter'], { stdio: 'ignore' });
   }
 }
@@ -2708,6 +3083,7 @@ async function startWorkLoop(channels, initialTarget) {
 
     if (!socket) {
       nextAgentdConnectAt = Date.now() + agentdReconnectBackoffMs;
+      logDebug(`[agent] agentd connect failed, retry in ${agentdReconnectBackoffMs}ms`);
       agentdReconnectBackoffMs = Math.min(agentdReconnectBackoffMs * 2, 30000);
       return false;
     }
@@ -2716,9 +3092,9 @@ async function startWorkLoop(channels, initialTarget) {
     nextAgentdConnectAt = 0;
     agentdReconnectBackoffMs = 1000;
     if (reason) {
-      console.log(`[agent] agentd connected (${reason})`);
+      logDebug(`[agent] agentd connected (${reason})`);
     } else {
-      console.log('[agent] agentd connected');
+      logDebug('[agent] agentd connected');
     }
     return true;
   };
@@ -2786,7 +3162,7 @@ async function startWorkLoop(channels, initialTarget) {
         if (now - lastQueuePullAt >= pollSec * 1000) {
           const pulled = await pullHookQueueForPane(tmuxTarget, tmuxPaneId).catch(() => 0);
           if (pulled > 0) {
-            console.log(`[agent] pulled ${pulled} queued hook delivery event(s) for pane=${tmuxPaneId}`);
+            logDebug(`[agent] pulled ${pulled} queued hook delivery event(s) for pane=${tmuxPaneId}`);
           }
           lastQueuePullAt = now;
         }
@@ -2922,7 +3298,7 @@ async function startWorkLoop(channels, initialTarget) {
 
     // STATE 2: MAIN WORKER MODE (tmuxTarget is set)
     // ============================================
-    let inFlight = await fetchCurrentTaskFromCoordinator().catch(() => null);
+    let inFlight = await fetchCurrentTaskFromCoordinator('work_loop.inflight_check').catch(() => null);
 
     if (inFlight && inFlight.id) {
       const taskId = inFlight.id;
@@ -3048,12 +3424,12 @@ async function main() {
     const detectedTarget = detectTmuxTarget(); // Deprecated: only for state dir fallback
 
     // DEBUG: Log pane ID detection for hook
-    process.stderr.write(`[agent] ═══ Hook Pane ID Detection ═══\n`);
-    process.stderr.write(`[agent] Hook type: ${type}\n`);
-    process.stderr.write(`[agent] $TMUX_PANE env: ${process.env.TMUX_PANE || 'NOT SET'}\n`);
-    process.stderr.write(`[agent] detectTmuxPaneId(): ${detectedPaneId || 'NULL'}\n`);
-    process.stderr.write(`[agent] detectTmuxTarget(): ${detectedTarget || 'NULL'}\n`);
-    process.stderr.write(`[agent] Will use pane_id: ${detectedPaneId || 'FALLBACK TO TARGET'}\n`);
+    logDebug('[agent] ═══ Hook Pane ID Detection ═══');
+    logDebug(`[agent] Hook type: ${type}`);
+    logDebug(`[agent] $TMUX_PANE env: ${process.env.TMUX_PANE || 'NOT SET'}`);
+    logDebug(`[agent] detectTmuxPaneId(): ${detectedPaneId || 'NULL'}`);
+    logDebug(`[agent] detectTmuxTarget(): ${detectedTarget || 'NULL'}`);
+    logDebug(`[agent] Will use pane_id: ${detectedPaneId || 'FALLBACK TO TARGET'}`);
 
     const state = configureStateDirForHook(detectedPaneId || detectedTarget);
     if (!(process.env.AGENT_NAME || '').trim() && state.label) {
@@ -3073,9 +3449,9 @@ async function main() {
       : null;
 
     if (queuedDelivery) {
-      process.stderr.write(`[agent] queued durable hook delivery: id=${queuedDelivery.delivery_id} pane=${queuedDelivery.pane_id}\n`);
+      logDebug(`[agent] queued durable hook delivery: id=${queuedDelivery.delivery_id} pane=${queuedDelivery.pane_id}`);
     } else {
-      process.stderr.write('[agent] durable queue skipped: pane_id unavailable\n');
+      logWarn('[agent] durable queue skipped: pane_id unavailable');
     }
 
     // 1) Preserve legacy behavior first (CWD/env needed by legacy hook).
@@ -3085,7 +3461,7 @@ async function main() {
     try {
       let ipcHandled = false;
       if (detectedPaneId && queuedDelivery) {
-        process.stderr.write(`[agent] Attempting agentd IPC for pane=${detectedPaneId}...\n`);
+        logDebug(`[agent] Attempting agentd IPC for pane=${detectedPaneId}...`);
         ipcHandled = await tryHookViaAgentd({
           paneId: detectedPaneId,
           hookType: type,
@@ -3094,9 +3470,9 @@ async function main() {
           createdAt: queuedDelivery.created_at,
         });
         if (ipcHandled) {
-          process.stderr.write(`[agent] Hook handled via agentd IPC\n`);
+          logDebug('[agent] Hook handled via agentd IPC');
         } else {
-          process.stderr.write(`[agent] agentd IPC unavailable, keeping queued delivery and trying direct coordinator fallback\n`);
+          logDebug('[agent] agentd IPC unavailable, keeping queued delivery and trying direct coordinator fallback');
         }
       }
 
@@ -3107,11 +3483,11 @@ async function main() {
         }
       }
     } catch (err) {
-      process.stderr.write(`[agent] Coordinator upload failed (ignored)\n`);
-      process.stderr.write(`[agent] Error type: ${err?.constructor?.name || 'Unknown'}\n`);
-      process.stderr.write(`[agent] Error message: ${String(err?.message || err)}\n`);
+      logWarn('[agent] Coordinator upload failed (ignored)');
+      logError(`[agent] Error type: ${err?.constructor?.name || 'Unknown'}`);
+      logError(`[agent] Error message: ${String(err?.message || err)}`);
       if (err?.stack) {
-        process.stderr.write(`[agent] Stack trace:\n${err.stack}\n`);
+        logDebug(`[agent] Stack trace:\n${err.stack}`);
       }
     }
 

--- a/coordinator/internal/store/memory/memory.go
+++ b/coordinator/internal/store/memory/memory.go
@@ -71,9 +71,6 @@ func (s *Store) UpsertAgent(_ context.Context, a model.Agent) (model.Agent, erro
 		if a.ClaudeStatus != "" {
 			existing.ClaudeStatus = a.ClaudeStatus
 		}
-		if a.CurrentTaskID != "" {
-			existing.CurrentTaskID = a.CurrentTaskID
-		}
 		if a.Meta != nil {
 			existing.Meta = a.Meta
 		}
@@ -89,6 +86,8 @@ func (s *Store) UpsertAgent(_ context.Context, a model.Agent) (model.Agent, erro
 	if a.ClaudeStatus == "" {
 		a.ClaudeStatus = model.ClaudeStatusIdle
 	}
+	// current_task_id is task-lifecycle-owned; do not set it from heartbeat/upsert payload.
+	a.CurrentTaskID = ""
 	a.LastSeen = now
 	a.CreatedAt = now
 	a.UpdatedAt = now
@@ -325,11 +324,8 @@ func (s *Store) DetachAgentFromChain(_ context.Context, req store.DetachAgentFro
 	s.chains[chainID] = chain
 	s.reevaluateChainStatus(chainID, now)
 
-	// Clear agent's current_task_id
-	if agent, ok := s.agents[agentID]; ok {
-		agent.CurrentTaskID = ""
-		agent.UpdatedAt = now
-		s.agents[agentID] = agent
+	if err := s.syncAgentCurrentTaskLocked(agentID, now); err != nil {
+		return err
 	}
 
 	return nil
@@ -360,6 +356,7 @@ func (s *Store) UpdateTaskStatus(_ context.Context, taskID string, newStatus mod
 	}
 
 	now := time.Now().UTC()
+	affectedAgentID := strings.TrimSpace(t.AssignedAgentID)
 
 	if newStatus == model.TaskStatusQueued {
 		t.Status = model.TaskStatusQueued
@@ -372,6 +369,9 @@ func (s *Store) UpdateTaskStatus(_ context.Context, taskID string, newStatus mod
 		t.UpdatedAt = now
 	}
 	s.tasks[taskID] = t
+	if err := s.syncAgentCurrentTaskLocked(affectedAgentID, now); err != nil {
+		return nil, err
+	}
 
 	// Re-evaluate chain status
 	if t.ChainID != "" {
@@ -501,6 +501,58 @@ func (s *Store) ListTasks(_ context.Context, f store.TaskFilter) ([]model.Task, 
 	return out, nil
 }
 
+// hasAnotherInProgressTaskForAgentLocked returns true when the agent already owns
+// another in-progress task (excluding exceptTaskID).
+// Must be called with s.mu held.
+func (s *Store) hasAnotherInProgressTaskForAgentLocked(agentID, exceptTaskID string) bool {
+	agentID = strings.TrimSpace(agentID)
+	exceptTaskID = strings.TrimSpace(exceptTaskID)
+	if agentID == "" {
+		return false
+	}
+
+	for _, t := range s.tasks {
+		if t.AssignedAgentID != agentID || t.Status != model.TaskStatusInProgress {
+			continue
+		}
+		if exceptTaskID != "" && t.ID == exceptTaskID {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// syncAgentCurrentTaskLocked derives agent.current_task_id from the task table.
+// Must be called with s.mu held.
+func (s *Store) syncAgentCurrentTaskLocked(agentID string, now time.Time) error {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil
+	}
+
+	agent, ok := s.agents[agentID]
+	if !ok {
+		return nil
+	}
+
+	var inProgressTaskID string
+	for _, t := range s.tasks {
+		if t.AssignedAgentID != agentID || t.Status != model.TaskStatusInProgress {
+			continue
+		}
+		if inProgressTaskID != "" && inProgressTaskID != t.ID {
+			return store.ErrConflict
+		}
+		inProgressTaskID = t.ID
+	}
+
+	agent.CurrentTaskID = inProgressTaskID
+	agent.UpdatedAt = now
+	s.agents[agentID] = agent
+	return nil
+}
+
 func (s *Store) ClaimTask(_ context.Context, req store.ClaimTaskRequest) (*model.Task, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -532,6 +584,9 @@ func (s *Store) ClaimTask(_ context.Context, req store.ClaimTaskRequest) (*model
 	}
 	if channelID == "" {
 		return nil, errWithCode("channel_id_or_channel_required")
+	}
+	if s.hasAnotherInProgressTaskForAgentLocked(req.AgentID, "") {
+		return nil, store.ErrConflict
 	}
 
 	// Check if agent already owns a chain
@@ -646,12 +701,8 @@ func (s *Store) ClaimTask(_ context.Context, req store.ClaimTaskRequest) (*model
 		s.claimIdem[key] = taskToClaim.ID
 	}
 
-	// Update agent's current_task_id (task claimed)
-	// NOTE: Do NOT update claude_status - heartbeat is sole source of truth
-	if agent, ok := s.agents[req.AgentID]; ok {
-		agent.CurrentTaskID = taskToClaim.ID
-		agent.UpdatedAt = now
-		s.agents[req.AgentID] = agent
+	if err := s.syncAgentCurrentTaskLocked(req.AgentID, now); err != nil {
+		return nil, err
 	}
 
 	return taskToClaim, nil
@@ -684,6 +735,9 @@ func (s *Store) AssignTask(_ context.Context, req store.AssignTaskRequest) (*mod
 	default:
 		return nil, store.ErrConflict
 	}
+	if s.hasAnotherInProgressTaskForAgentLocked(req.AgentID, t.ID) {
+		return nil, store.ErrConflict
+	}
 
 	now := time.Now().UTC()
 	t.Status = model.TaskStatusInProgress
@@ -694,12 +748,8 @@ func (s *Store) AssignTask(_ context.Context, req store.AssignTaskRequest) (*mod
 	t.UpdatedAt = now
 	s.tasks[t.ID] = t
 
-	// Update agent's current_task_id (task assigned)
-	// NOTE: Do NOT update claude_status - heartbeat is sole source of truth
-	if agent, ok := s.agents[req.AgentID]; ok {
-		agent.CurrentTaskID = t.ID
-		agent.UpdatedAt = now
-		s.agents[req.AgentID] = agent
+	if err := s.syncAgentCurrentTaskLocked(req.AgentID, now); err != nil {
+		return nil, err
 	}
 
 	return &t, nil
@@ -750,18 +800,12 @@ func (s *Store) CompleteTask(_ context.Context, req store.CompleteTaskRequest) (
 		return nil, store.ErrConflict
 	}
 
-	// Clear agent's current_task_id (task is complete)
-	// NOTE: Do NOT update claude_status - heartbeat is sole source of truth
 	agentID := strings.TrimSpace(req.AgentID)
 	if agentID == "" {
 		agentID = strings.TrimSpace(t.AssignedAgentID)
 	}
-	if agentID != "" {
-		if agent, ok := s.agents[agentID]; ok {
-			agent.CurrentTaskID = ""
-			agent.UpdatedAt = now
-			s.agents[agentID] = agent
-		}
+	if err := s.syncAgentCurrentTaskLocked(agentID, now); err != nil {
+		return nil, err
 	}
 
 	// Update chain status (but NOT ownership - ownership persists until explicit detach)
@@ -841,18 +885,12 @@ func (s *Store) FailTask(_ context.Context, req store.FailTaskRequest) (*model.T
 		return nil, store.ErrConflict
 	}
 
-	// Clear agent's current_task_id (task failed)
-	// NOTE: Do NOT update claude_status - heartbeat is sole source of truth
 	agentID := strings.TrimSpace(req.AgentID)
 	if agentID == "" {
 		agentID = strings.TrimSpace(t.AssignedAgentID)
 	}
-	if agentID != "" {
-		if agent, ok := s.agents[agentID]; ok {
-			agent.CurrentTaskID = ""
-			agent.UpdatedAt = now
-			s.agents[agentID] = agent
-		}
+	if err := s.syncAgentCurrentTaskLocked(agentID, now); err != nil {
+		return nil, err
 	}
 
 	// Update chain status (but NOT ownership - ownership persists until explicit detach)

--- a/coordinator/internal/store/postgres/postgres.go
+++ b/coordinator/internal/store/postgres/postgres.go
@@ -62,14 +62,20 @@ func (s *Store) UpsertAgent(ctx context.Context, a model.Agent) (model.Agent, er
 		}
 	}
 
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return model.Agent{}, mapPgErr(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var out model.Agent
 	if strings.TrimSpace(a.ID) == "" {
-		// Let DB generate UUID.
-		var out model.Agent
-		err := s.pool.QueryRow(ctx, `
+		// current_task_id is task-lifecycle-owned; do not set it from heartbeat/upsert payload.
+		err = tx.QueryRow(ctx, `
 			insert into public.agents (name, status, claude_status, current_task_id, last_seen, meta, user_id)
-			values ($1, $2, $3, nullif($4, '')::uuid, $5, $6::jsonb, nullif($7, '')::uuid)
+			values ($1, $2, $3, null, $4, $5::jsonb, nullif($6, '')::uuid)
 			returning id::text, coalesce(user_id::text, ''), name, status, claude_status, coalesce(current_task_id::text, ''), last_seen, meta, created_at, updated_at
-		`, a.Name, string(a.Status), string(a.ClaudeStatus), a.CurrentTaskID, now, string(metaJSON), a.UserID).Scan(
+		`, a.Name, string(a.Status), string(a.ClaudeStatus), now, string(metaJSON), a.UserID).Scan(
 			&out.ID,
 			&out.UserID,
 			&out.Name,
@@ -81,44 +87,68 @@ func (s *Store) UpsertAgent(ctx context.Context, a model.Agent) (model.Agent, er
 			&out.CreatedAt,
 			&out.UpdatedAt,
 		)
-		if err != nil {
-			return model.Agent{}, mapPgErr(err)
-		}
-		_ = json.Unmarshal(metaJSON, &out.Meta)
-		return out, nil
+	} else {
+		// Keep existing current_task_id; it is synchronized by task lifecycle transitions.
+		err = tx.QueryRow(ctx, `
+			insert into public.agents (id, name, status, claude_status, current_task_id, last_seen, meta, user_id)
+			values ($1::uuid, $2, $3, $4, null, $5, $6::jsonb, nullif($7, '')::uuid)
+			on conflict (id) do update
+			set name = excluded.name,
+			    status = excluded.status,
+			    claude_status = excluded.claude_status,
+			    last_seen = excluded.last_seen,
+			    meta = excluded.meta,
+			    user_id = coalesce(excluded.user_id, public.agents.user_id),
+			    updated_at = now()
+			returning id::text, coalesce(user_id::text, ''), name, status, claude_status, coalesce(current_task_id::text, ''), last_seen, meta, created_at, updated_at
+		`, a.ID, a.Name, string(a.Status), string(a.ClaudeStatus), now, string(metaJSON), a.UserID).Scan(
+			&out.ID,
+			&out.UserID,
+			&out.Name,
+			&out.Status,
+			&out.ClaudeStatus,
+			&out.CurrentTaskID,
+			&out.LastSeen,
+			&metaJSON,
+			&out.CreatedAt,
+			&out.UpdatedAt,
+		)
 	}
-
-	var out model.Agent
-	err := s.pool.QueryRow(ctx, `
-		insert into public.agents (id, name, status, claude_status, current_task_id, last_seen, meta, user_id)
-		values ($1::uuid, $2, $3, $4, nullif($5, '')::uuid, $6, $7::jsonb, nullif($8, '')::uuid)
-		on conflict (id) do update
-		set name = excluded.name,
-		    status = excluded.status,
-		    claude_status = excluded.claude_status,
-		    current_task_id = excluded.current_task_id,
-		    last_seen = excluded.last_seen,
-		    meta = excluded.meta,
-		    user_id = coalesce(excluded.user_id, public.agents.user_id),
-		    updated_at = now()
-		returning id::text, coalesce(user_id::text, ''), name, status, claude_status, coalesce(current_task_id::text, ''), last_seen, meta, created_at, updated_at
-	`, a.ID, a.Name, string(a.Status), string(a.ClaudeStatus), a.CurrentTaskID, now, string(metaJSON), a.UserID).Scan(
-		&out.ID,
-		&out.UserID,
-		&out.Name,
-		&out.Status,
-		&out.ClaudeStatus,
-		&out.CurrentTaskID,
-		&out.LastSeen,
-		&metaJSON,
-		&out.CreatedAt,
-		&out.UpdatedAt,
-	)
 	if err != nil {
 		return model.Agent{}, mapPgErr(err)
 	}
-	_ = json.Unmarshal(metaJSON, &out.Meta)
-	return out, nil
+
+	if err := s.syncAgentCurrentTaskTx(ctx, tx, out.ID); err != nil {
+		return model.Agent{}, err
+	}
+
+	var final model.Agent
+	var finalMetaJSON []byte
+	if err := tx.QueryRow(ctx, `
+		select id::text, coalesce(user_id::text, ''), name, status, claude_status, coalesce(current_task_id::text, ''), last_seen, meta, created_at, updated_at
+		from public.agents
+		where id = $1::uuid
+	`, out.ID).Scan(
+		&final.ID,
+		&final.UserID,
+		&final.Name,
+		&final.Status,
+		&final.ClaudeStatus,
+		&final.CurrentTaskID,
+		&final.LastSeen,
+		&finalMetaJSON,
+		&final.CreatedAt,
+		&final.UpdatedAt,
+	); err != nil {
+		return model.Agent{}, mapPgErr(err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return model.Agent{}, mapPgErr(err)
+	}
+
+	_ = json.Unmarshal(finalMetaJSON, &final.Meta)
+	return final, nil
 }
 
 func (s *Store) ListAgents(ctx context.Context, userID string) ([]model.Agent, error) {
@@ -444,14 +474,8 @@ func (s *Store) DetachAgentFromChain(ctx context.Context, req store.DetachAgentF
 		return err
 	}
 
-	// Clear agent's current_task_id
-	_, err = tx.Exec(ctx, `
-		update public.agents
-		set current_task_id = null, updated_at = now()
-		where id = $1::uuid
-	`, req.AgentID)
-	if err != nil {
-		return mapPgErr(err)
+	if err := s.syncAgentCurrentTaskTx(ctx, tx, req.AgentID); err != nil {
+		return err
 	}
 
 	return tx.Commit(ctx)
@@ -735,6 +759,59 @@ func (s *Store) ListTasks(ctx context.Context, f store.TaskFilter) ([]model.Task
 	return out, nil
 }
 
+// syncAgentCurrentTaskTx derives agents.current_task_id from tasks assigned to the agent.
+// Must be called within the same transaction as task lifecycle mutations.
+func (s *Store) syncAgentCurrentTaskTx(ctx context.Context, tx pgx.Tx, agentID string) error {
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil
+	}
+
+	rows, err := tx.Query(ctx, `
+		select id::text
+		from public.tasks
+		where assigned_agent_id = $1::uuid
+		  and status = 'in_progress'
+		order by claimed_at asc nulls last, created_at asc, id asc
+		limit 2
+	`, agentID)
+	if err != nil {
+		return mapPgErr(err)
+	}
+	defer rows.Close()
+
+	taskIDs := make([]string, 0, 2)
+	for rows.Next() {
+		var taskID string
+		if err := rows.Scan(&taskID); err != nil {
+			return mapPgErr(err)
+		}
+		taskIDs = append(taskIDs, taskID)
+	}
+	if err := rows.Err(); err != nil {
+		return mapPgErr(err)
+	}
+	if len(taskIDs) > 1 {
+		return store.ErrConflict
+	}
+
+	currentTaskID := ""
+	if len(taskIDs) == 1 {
+		currentTaskID = taskIDs[0]
+	}
+
+	if _, err := tx.Exec(ctx, `
+		update public.agents
+		set current_task_id = nullif($2, '')::uuid,
+		    updated_at = now()
+		where id = $1::uuid
+	`, agentID, currentTaskID); err != nil {
+		return mapPgErr(err)
+	}
+
+	return nil
+}
+
 func (s *Store) ClaimTask(ctx context.Context, req store.ClaimTaskRequest) (*model.Task, error) {
 	if strings.TrimSpace(req.AgentID) == "" {
 		return nil, errors.New("agent_id_required")
@@ -808,14 +885,9 @@ func (s *Store) ClaimTask(ctx context.Context, req store.ClaimTaskRequest) (*mod
 				return nil, mapPgErr(err)
 			}
 
-			// Update agent's current_task_id.
-			// NOTE: Do NOT update claude_status - heartbeat is sole source of truth
-			_, _ = tx.Exec(ctx, `
-				update public.agents
-				set current_task_id = $2::uuid,
-				    updated_at = now()
-				where id = $1::uuid
-			`, req.AgentID, out.ID)
+			if err := s.syncAgentCurrentTaskTx(ctx, tx, req.AgentID); err != nil {
+				return nil, err
+			}
 
 			if err := tx.Commit(ctx); err != nil {
 				return nil, mapPgErr(err)
@@ -861,14 +933,9 @@ func (s *Store) ClaimTask(ctx context.Context, req store.ClaimTaskRequest) (*mod
 		`, req.AgentID, idemKey, t.ID)
 	}
 
-	// Update agent's current_task_id.
-	// NOTE: Do NOT update claude_status - heartbeat is sole source of truth
-	_, _ = tx.Exec(ctx, `
-		update public.agents
-		set current_task_id = $2::uuid,
-		    updated_at = now()
-		where id = $1::uuid
-	`, req.AgentID, t.ID)
+	if err := s.syncAgentCurrentTaskTx(ctx, tx, req.AgentID); err != nil {
+		return nil, err
+	}
 
 	if err := tx.Commit(ctx); err != nil {
 		return nil, mapPgErr(err)
@@ -957,14 +1024,9 @@ func (s *Store) AssignTask(ctx context.Context, req store.AssignTaskRequest) (*m
 		}
 	}
 
-	// Update agent's current_task_id.
-	// NOTE: Do NOT update claude_status - heartbeat is sole source of truth
-	_, _ = tx.Exec(ctx, `
-		update public.agents
-		set current_task_id = $2::uuid,
-		    updated_at = now()
-		where id = $1::uuid
-	`, req.AgentID, t.ID)
+	if err := s.syncAgentCurrentTaskTx(ctx, tx, req.AgentID); err != nil {
+		return nil, err
+	}
 
 	if err := tx.Commit(ctx); err != nil {
 		return nil, mapPgErr(err)
@@ -1113,19 +1175,12 @@ func (s *Store) CompleteTask(ctx context.Context, req store.CompleteTaskRequest)
 		}
 	}
 
-	// Clear agent's current_task_id (task is complete)
-	// NOTE: Do NOT update claude_status - heartbeat is sole source of truth
 	agentID := strings.TrimSpace(req.AgentID)
 	if agentID == "" {
 		agentID = strings.TrimSpace(t.AssignedAgentID)
 	}
-	if agentID != "" {
-		_, _ = tx.Exec(ctx, `
-			update public.agents
-			set current_task_id = null,
-			    updated_at = now()
-			where id = $1::uuid
-		`, agentID)
+	if err := s.syncAgentCurrentTaskTx(ctx, tx, agentID); err != nil {
+		return nil, err
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -1239,19 +1294,12 @@ func (s *Store) FailTask(ctx context.Context, req store.FailTaskRequest) (*model
 		}
 	}
 
-	// Clear agent's current_task_id (task failed)
-	// NOTE: Do NOT update claude_status - heartbeat is sole source of truth
 	agentID := strings.TrimSpace(req.AgentID)
 	if agentID == "" {
 		agentID = strings.TrimSpace(t.AssignedAgentID)
 	}
-	if agentID != "" {
-		_, _ = tx.Exec(ctx, `
-			update public.agents
-			set current_task_id = null,
-			    updated_at = now()
-			where id = $1::uuid
-		`, agentID)
+	if err := s.syncAgentCurrentTaskTx(ctx, tx, agentID); err != nil {
+		return nil, err
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/supabase/migrations/0019_single_in_progress_task_per_agent.sql
+++ b/supabase/migrations/0019_single_in_progress_task_per_agent.sql
@@ -1,0 +1,5 @@
+-- Enforce at most one in-progress task per agent.
+-- done/failed tasks may keep assigned_agent_id for history.
+create unique index if not exists uq_tasks_single_in_progress_per_agent
+on public.tasks (assigned_agent_id)
+where status = 'in_progress' and assigned_agent_id is not null;

--- a/tasks/0083-agent-log-level-debug-control.md
+++ b/tasks/0083-agent-log-level-debug-control.md
@@ -1,0 +1,20 @@
+# Agent 로그 레벨 제어 (debug/info/warn/error)
+
+## 요구사항
+- `agent/clw-agent.js`에서 로그 레벨을 사용자가 설정할 수 있어야 한다.
+- agentd 연결/등록/복구 및 hook 전달 관련 로그를 `debug` 레벨로 제어 가능해야 한다.
+
+## 작업 목록
+- [x] `REQUIREMENTS.md`에 agent 로그 레벨 제어 요구사항 추가
+- [x] `tasks/INDEX.md`에 신규 작업 등록
+- [x] `agent/clw-agent.js`에 로그 레벨 유틸 추가 (`AGENT_LOG_LEVEL`)
+- [x] agentd 연결/등록 로그를 `debug` 레벨로 전환
+- [x] 사용법(환경변수) 안내 메시지 반영
+- [x] 문법 체크 수행 (`node --check agent/clw-agent.js`)
+- [x] 작업 완료 후 체크리스트 업데이트
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `tasks/INDEX.md`
+- `tasks/0083-agent-log-level-debug-control.md`
+- `agent/clw-agent.js`

--- a/tasks/0084-hook-delivery-debug-trace-logging.md
+++ b/tasks/0084-hook-delivery-debug-trace-logging.md
@@ -1,0 +1,21 @@
+# Hook Delivery Debug Trace Logging
+
+## 요구사항
+- durable queue 기반 훅 전달의 전체 파이프라인을 `debug` 레벨에서 추적 가능해야 한다.
+- enqueue부터 agentd 전달, worker 수신/ACK, pull/replay까지 단계별 로그를 남겨야 한다.
+
+## 작업 목록
+- [x] `REQUIREMENTS.md`에 Hook Delivery Trace 로그 요구사항 추가
+- [x] `tasks/INDEX.md`에 신규 작업 등록
+- [x] `agent/clw-agent.js`에 hook-flow debug 로깅 헬퍼 추가
+- [x] queue enqueue/ack/deadletter 단계 로그 추가
+- [x] IPC send/result 및 agentd forward/ack 단계 로그 추가
+- [x] worker hook_forward/pull/replay 단계 로그 추가
+- [x] 문법 체크 수행 (`node --check agent/clw-agent.js`)
+- [x] 작업 완료 후 체크리스트 업데이트
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `tasks/INDEX.md`
+- `tasks/0084-hook-delivery-debug-trace-logging.md`
+- `agent/clw-agent.js`

--- a/tasks/0085-hook-completed-complete-api-test.md
+++ b/tasks/0085-hook-completed-complete-api-test.md
@@ -1,0 +1,18 @@
+# Hook Completed Complete API 테스트
+
+## 요구사항
+- `clw-agent.js hook completed` 실행 시, 에이전트가 현재 task를 조회한 뒤 `POST /v1/tasks/complete`를 호출해야 한다.
+- 테스트는 BDD(`Given-When-Then`) 시나리오 이름으로 작성한다.
+
+## 작업 목록
+- [x] `REQUIREMENTS.md`에 해당 테스트 요구사항 반영
+- [x] `tasks/INDEX.md`에 신규 작업 등록
+- [x] `agent/tests/integration/`에 hook completed complete API 호출 검증 테스트 추가
+- [x] 테스트 실행 (`node --test agent/tests/integration/hook-completed-complete-api.test.js`)
+- [x] 작업 완료 후 체크리스트 업데이트
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `tasks/INDEX.md`
+- `tasks/0085-hook-completed-complete-api-test.md`
+- `agent/tests/integration/hook-completed-complete-api.test.js`

--- a/tasks/0086-agentd-multi-worker-hook-routing-test.md
+++ b/tasks/0086-agentd-multi-worker-hook-routing-test.md
@@ -1,0 +1,18 @@
+# Agentd 멀티 워커 Hook 라우팅 통합 테스트
+
+## 요구사항
+- 별도 터미널에서 `clw-agent.js hook completed`가 실행되면 `agentd`를 통해 해당 pane_id worker로 라우팅되어야 한다.
+- 복수 worker가 등록된 상황에서도 대상 pane worker만 coordinator 완료 API(`POST /v1/tasks/complete`)를 호출해야 한다.
+
+## 작업 목록
+- [x] `REQUIREMENTS.md`에 멀티 worker hook 라우팅 통합 테스트 요구사항 반영
+- [x] `tasks/INDEX.md`에 신규 작업 등록
+- [x] `agent/tests/integration/`에 agentd 멀티 worker hook 라우팅 테스트 추가
+- [x] 테스트 실행 (`node --test agent/tests/integration/hook-agentd-multi-worker-routing.test.js`)
+- [x] 작업 완료 후 체크리스트 업데이트
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `tasks/INDEX.md`
+- `tasks/0086-agentd-multi-worker-hook-routing-test.md`
+- `agent/tests/integration/hook-agentd-multi-worker-routing.test.js`

--- a/tasks/0086-remove-agent-id-env-bootstrap-and-current-task-debug-log.md
+++ b/tasks/0086-remove-agent-id-env-bootstrap-and-current-task-debug-log.md
@@ -1,0 +1,18 @@
+# Remove AGENT_ID Bootstrap + Current Task Debug Logging
+
+## 요구사항
+- Agent는 프로세스 시작 시 `AGENT_ID` 환경변수로 `_currentAgentId`를 초기화하지 않아야 한다.
+- `hook completed` 처리 중 current task 조회(`GET /v1/agents/{id}/current-task`) 요청/응답을 `debug` 레벨로 기록해야 한다.
+
+## 작업 목록
+- [x] `REQUIREMENTS.md`에 요구사항 반영
+- [x] `tasks/0086-remove-agent-id-env-bootstrap-and-current-task-debug-log.md` 작업 파일 생성
+- [x] `agent/clw-agent.js`에서 `_currentAgentId`의 `AGENT_ID` 초기화 제거
+- [x] `agent/clw-agent.js`에서 current task 조회 요청/응답 debug 로그 추가
+- [x] `agent/clw-agent.js` 문법 체크 실행 (`node --check agent/clw-agent.js`)
+- [x] 작업 완료 후 체크리스트 업데이트
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `tasks/0086-remove-agent-id-env-bootstrap-and-current-task-debug-log.md`
+- `agent/clw-agent.js`

--- a/tasks/0087-fix-agent-task-assignment-sync.md
+++ b/tasks/0087-fix-agent-task-assignment-sync.md
@@ -1,0 +1,29 @@
+# Agent-Task 할당 동기화 정합성 보강
+
+## 요구사항
+- `tasks.assigned_agent_id`와 `agents.current_task_id`는 어느 한쪽만 변경되지 않도록 항상 함께 동기화되어야 한다.
+- `done`/`failed` Task는 과거 이력 보존을 위해 `assigned_agent_id`를 유지할 수 있다.
+- `in_progress` 상태에서는 하나의 Agent가 동시에 하나의 Task만 담당할 수 있어야 한다.
+
+## 작업 목록
+- [x] `REQUIREMENTS.md`에 동기화 정합성 요구사항 반영
+- [x] `tasks/0087-fix-agent-task-assignment-sync.md` 작업 파일 생성
+- [x] `tasks/INDEX.md`에 신규 작업 등록
+- [x] Memory Store에 Agent-Task 동기화 편의 메서드 추가 및 claim/assign/complete/fail/detach 경로 적용
+- [x] Postgres Store에 Agent-Task 동기화 편의 메서드 추가 및 claim/assign/complete/fail/detach 경로 적용
+- [x] Postgres 스키마에 `in_progress` 기준 Agent 단일 task 제약(부분 unique index) 반영
+- [x] 관련 테스트 추가/수정
+- [x] 변경 파일 `gofmt` 적용
+- [x] 테스트 실행 및 결과 확인
+- [x] 작업 완료 후 체크리스트 업데이트
+
+## 변경 파일
+- `REQUIREMENTS.md`
+- `tasks/INDEX.md`
+- `tasks/0087-fix-agent-task-assignment-sync.md`
+- `coordinator/internal/store/memory/memory.go`
+- `coordinator/internal/store/memory/memory_test.go`
+- `coordinator/internal/store/postgres/postgres.go`
+- `coordinator/internal/store/postgres/postgres_test.go`
+- `supabase/migrations/0000_full_init.sql`
+- `supabase/migrations/0019_single_in_progress_task_per_agent.sql`


### PR DESCRIPTION
## Summary
- add debug logging trace for clw-agent hook delivery flow
- harden agent/task sync so one agent can hold only one in_progress task
- include follow-up fix/test/db commits after hook-flow logging

## Included commits
- e409569 feat: add logging on clw-agent hook flow
- c34d4b8 docs: add logging on clw-agent hook flow
- 55d3b49 fix: only one in_progress task per agent
- a340876 docs: only one in_progress task per agent
- 13ffcbc fix: find clw-agent.js path by exe-environment
- 201db6c test: hook completed test
- c46746d db: add index(assigned_agent_id)

## Test
- not run in this PR creation step